### PR TITLE
[TASK-12] Add AuthUser to Route Handlers

### DIFF
--- a/backend/src/country/routes.rs
+++ b/backend/src/country/routes.rs
@@ -10,6 +10,7 @@ use axum::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::auth::AuthUser;
 use crate::common::paging::{PagedResponse, Paging};
 use crate::country::service::{self, CountryFilters};
 use crate::http::ApiContext;
@@ -44,6 +45,7 @@ pub struct CountryQueryParams {
 async fn list_countries(
     Query(params): Query<CountryQueryParams>, // This uses axum's Query
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
 ) -> impl IntoApiResponse {
     let filters = CountryFilters::new(
         params.enabled,
@@ -115,6 +117,7 @@ struct SelectCountry {
 
 async fn get_country(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(country): Path<SelectCountry>,
 ) -> impl IntoApiResponse {
     match service::get_country_by_id(&ctx.db, country.id).await {
@@ -151,6 +154,7 @@ fn get_country_docs(op: TransformOperation) -> TransformOperation {
 
 async fn update_country_status(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(country_id): Path<i64>,
     Json(status): Json<bool>,
 ) -> impl IntoApiResponse {

--- a/backend/src/event/routes.rs
+++ b/backend/src/event/routes.rs
@@ -14,6 +14,7 @@ use axum::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::auth::AuthUser;
 use crate::common::paging::{PagedResponse, Paging};
 use crate::event::business::EventBusinessLogic;
 use crate::event::service::EventFilters;
@@ -70,6 +71,7 @@ struct UpdateEventRequest {
 
 async fn create_event(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Json(request): Json<CreateEventRequest>,
 ) -> impl IntoApiResponse {
     // 🎯 Route Handler: Only HTTP concerns
@@ -91,6 +93,7 @@ fn create_event_docs(op: TransformOperation) -> TransformOperation {
 async fn list_events(
     Query(params): Query<EventQueryParams>,
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
 ) -> impl IntoApiResponse {
     let filters = EventFilters::new(params.name, params.country_id);
     let paging = Paging::new(params.page.unwrap_or(1), params.page_size.unwrap_or(15));
@@ -134,6 +137,7 @@ struct SelectEvent {
 
 async fn get_event(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(event): Path<SelectEvent>,
 ) -> impl IntoApiResponse {
     // 🎯 Route Handler: Only HTTP concerns
@@ -162,6 +166,7 @@ fn get_event_docs(op: TransformOperation) -> TransformOperation {
 
 async fn update_event(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(event_id): Path<i64>,
     Json(update_request): Json<UpdateEventRequest>,
 ) -> impl IntoApiResponse {
@@ -194,6 +199,7 @@ fn update_event_docs(op: TransformOperation) -> TransformOperation {
 
 async fn delete_event(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(event): Path<SelectEvent>,
 ) -> impl IntoApiResponse {
     // 🎯 Route Handler: Only HTTP concerns

--- a/backend/src/player/routes.rs
+++ b/backend/src/player/routes.rs
@@ -14,6 +14,7 @@ use axum::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::auth::AuthUser;
 use crate::common::paging::{PagedResponse, Paging};
 use crate::http::ApiContext;
 use crate::player::business::PlayerBusinessLogic;
@@ -70,6 +71,7 @@ struct PlayerCreateResponse {
 
 async fn create_player(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Json(player): Json<CreatePlayerRequest>,
 ) -> impl IntoApiResponse {
     match PlayerBusinessLogic::create_player(
@@ -96,6 +98,7 @@ fn create_player_docs(op: TransformOperation) -> TransformOperation {
 
 async fn list_players(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Query(params): Query<PlayerQueryParams>,
 ) -> impl IntoApiResponse {
     let paging = Some(Paging::new(
@@ -128,6 +131,7 @@ struct SelectPlayer {
 
 async fn get_player(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(player): Path<SelectPlayer>,
 ) -> impl IntoApiResponse {
     match PlayerBusinessLogic::get_player(&ctx, player.id).await {
@@ -169,6 +173,7 @@ struct UpdatePlayerRequest {
 
 async fn update_player(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(player): Path<SelectPlayer>,
     Json(update_data): Json<UpdatePlayerRequest>,
 ) -> impl IntoApiResponse {
@@ -195,6 +200,7 @@ fn update_player_docs(op: TransformOperation) -> TransformOperation {
 
 async fn delete_player(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(player): Path<SelectPlayer>,
 ) -> impl IntoApiResponse {
     match PlayerBusinessLogic::delete_player(&ctx, player.id).await {

--- a/backend/src/player_contract/routes.rs
+++ b/backend/src/player_contract/routes.rs
@@ -9,6 +9,7 @@ use axum::{extract::Path, http::StatusCode, response::IntoResponse, Extension, J
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::auth::AuthUser;
 use crate::http::ApiContext;
 use crate::player_contract::business::PlayerContractBusinessLogic;
 
@@ -46,6 +47,7 @@ struct PlayerContractCreateResponse {
 
 async fn create_player_contract(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Json(participation): Json<CreatePlayerContractRequest>,
 ) -> impl IntoApiResponse {
     match PlayerContractBusinessLogic::create_player_contract(
@@ -69,7 +71,10 @@ fn create_player_contract_docs(op: TransformOperation) -> TransformOperation {
         .response::<201, Json<PlayerContractCreateResponse>>()
 }
 
-async fn list_player_contracts(Extension(ctx): Extension<ApiContext>) -> impl IntoApiResponse {
+async fn list_player_contracts(
+    Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
+) -> impl IntoApiResponse {
     match PlayerContractBusinessLogic::list_player_contracts(&ctx).await {
         Ok(result) => Ok(Json(result)),
         Err(app_error) => Err(app_error.into_response()),
@@ -89,6 +94,7 @@ struct SelectPlayerContract {
 
 async fn get_player_contract(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(contract): Path<SelectPlayerContract>,
 ) -> impl IntoApiResponse {
     match PlayerContractBusinessLogic::get_player_contract(&ctx, contract.id).await {
@@ -112,6 +118,7 @@ fn get_player_contract_docs(op: TransformOperation) -> TransformOperation {
 
 async fn delete_player_contract(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(contract): Path<SelectPlayerContract>,
 ) -> impl IntoApiResponse {
     match PlayerContractBusinessLogic::delete_player_contract(&ctx, contract.id).await {

--- a/backend/src/season/routes.rs
+++ b/backend/src/season/routes.rs
@@ -14,6 +14,7 @@ use axum::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::auth::AuthUser;
 use crate::common::paging::{PagedResponse, Paging};
 use crate::http::ApiContext;
 use crate::season::business::SeasonBusinessLogic;
@@ -78,6 +79,7 @@ struct SeasonCreateResponse {
 
 async fn create_season(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Json(season): Json<CreateSeasonRequest>,
 ) -> impl IntoApiResponse {
     match SeasonBusinessLogic::create_season(
@@ -104,6 +106,7 @@ fn create_season_docs(op: TransformOperation) -> TransformOperation {
 
 async fn list_seasons(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Query(params): Query<SeasonQueryParams>,
 ) -> impl IntoApiResponse {
     let paging = Some(Paging::new(
@@ -136,6 +139,7 @@ struct SelectSeason {
 
 async fn get_season(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(season): Path<SelectSeason>,
 ) -> impl IntoApiResponse {
     match SeasonBusinessLogic::get_season(&ctx, season.id).await {
@@ -174,6 +178,7 @@ struct UpdateSeasonRequest {
 
 async fn update_season(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(season): Path<SelectSeason>,
     Json(update_data): Json<UpdateSeasonRequest>,
 ) -> impl IntoApiResponse {
@@ -200,6 +205,7 @@ fn update_season_docs(op: TransformOperation) -> TransformOperation {
 
 async fn delete_season(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(season): Path<SelectSeason>,
 ) -> impl IntoApiResponse {
     match SeasonBusinessLogic::delete_season(&ctx, season.id).await {
@@ -215,7 +221,10 @@ fn delete_season_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<404, (), _>(|res| res.description("The season was not found"))
 }
 
-async fn list_seasons_simple(Extension(ctx): Extension<ApiContext>) -> impl IntoApiResponse {
+async fn list_seasons_simple(
+    Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
+) -> impl IntoApiResponse {
     match SeasonBusinessLogic::get_seasons_list(&ctx).await {
         Ok(result) => Ok(Json(result)),
         Err(app_error) => Err(app_error.into_response()),
@@ -238,6 +247,7 @@ struct SeasonTeamParams {
 
 async fn get_season_team_players(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(params): Path<SeasonTeamParams>,
 ) -> impl IntoApiResponse {
     match SeasonBusinessLogic::get_players_for_team_in_season(

--- a/backend/src/team/routes.rs
+++ b/backend/src/team/routes.rs
@@ -14,6 +14,7 @@ use axum::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::auth::AuthUser;
 use crate::common::paging::{PagedResponse, Paging};
 use crate::errors::AppError;
 use crate::http::ApiContext;
@@ -76,6 +77,7 @@ struct TeamCreateResponse {
 
 async fn create_team(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Json(request): Json<CreateTeamRequest>,
 ) -> impl IntoApiResponse {
     // 🎯 Route Handler: Only HTTP concerns
@@ -98,6 +100,7 @@ fn create_team_docs(op: TransformOperation) -> TransformOperation {
 
 async fn list_teams(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Query(params): Query<TeamQueryParams>,
 ) -> impl IntoApiResponse {
     let filters = TeamFilters::new(params.name, params.country_id);
@@ -123,6 +126,7 @@ struct SelectTeam {
 
 async fn get_team(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(team): Path<SelectTeam>,
 ) -> impl IntoApiResponse {
     // 🎯 Route Handler: Only HTTP concerns
@@ -163,6 +167,7 @@ struct UpdateTeamRequest {
 
 async fn update_team(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(team): Path<SelectTeam>,
     Json(update_data): Json<UpdateTeamRequest>,
 ) -> impl IntoApiResponse {
@@ -189,6 +194,7 @@ fn update_team_docs(op: TransformOperation) -> TransformOperation {
 
 async fn delete_team(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(team): Path<SelectTeam>,
 ) -> impl IntoApiResponse {
     match TeamBusinessLogic::delete_team(&ctx, team.id).await {
@@ -204,7 +210,10 @@ fn delete_team_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<404, (), _>(|res| res.description("The team was not found"))
 }
 
-async fn list_teams_simple(Extension(ctx): Extension<ApiContext>) -> impl IntoApiResponse {
+async fn list_teams_simple(
+    Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
+) -> impl IntoApiResponse {
     match TeamBusinessLogic::get_teams_list(&ctx).await {
         Ok(result) => Ok(Json(result)),
         Err(err) => Err(err.into_response()),
@@ -220,6 +229,7 @@ fn list_teams_simple_docs(op: TransformOperation) -> TransformOperation {
 /// Get team detail with participations and roster
 async fn get_team_detail(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(id): Path<i64>,
 ) -> impl IntoApiResponse {
     match TeamBusinessLogic::get_team_detail(&ctx, id).await {

--- a/backend/src/team_participation/routes.rs
+++ b/backend/src/team_participation/routes.rs
@@ -9,6 +9,7 @@ use axum::{extract::Path, http::StatusCode, response::IntoResponse, Extension, J
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::auth::AuthUser;
 use crate::http::ApiContext;
 use crate::team_participation::business::TeamParticipationBusinessLogic;
 
@@ -53,6 +54,7 @@ struct TeamParticipationCreateResponse {
 
 async fn create_team_participation(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Json(participation): Json<CreateTeamParticipationRequest>,
 ) -> impl IntoApiResponse {
     match TeamParticipationBusinessLogic::create_team_participation(
@@ -76,7 +78,10 @@ fn create_team_participation_docs(op: TransformOperation) -> TransformOperation 
         .response::<201, Json<TeamParticipationCreateResponse>>()
 }
 
-async fn list_team_participation(Extension(ctx): Extension<ApiContext>) -> impl IntoApiResponse {
+async fn list_team_participation(
+    Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
+) -> impl IntoApiResponse {
     match TeamParticipationBusinessLogic::list_team_participations(&ctx).await {
         Ok(result) => Ok(Json(result)),
         Err(app_error) => Err(app_error.into_response()),
@@ -96,6 +101,7 @@ struct SelectTeamParticipation {
 
 async fn get_team_participation(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(participation): Path<SelectTeamParticipation>,
 ) -> impl IntoApiResponse {
     match TeamParticipationBusinessLogic::get_team_participation(&ctx, participation.id).await {
@@ -119,6 +125,7 @@ fn get_team_participation_docs(op: TransformOperation) -> TransformOperation {
 
 async fn delete_team_participation(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Path(participation): Path<SelectTeamParticipation>,
 ) -> impl IntoApiResponse {
     match TeamParticipationBusinessLogic::delete_team_participation(&ctx, participation.id).await {
@@ -138,6 +145,7 @@ fn delete_team_participation_docs(op: TransformOperation) -> TransformOperation 
 
 async fn find_or_create_team_participation_route(
     Extension(ctx): Extension<ApiContext>,
+    Extension(_user): Extension<AuthUser>,
     Json(participation): Json<CreateTeamParticipationRequest>,
 ) -> impl IntoApiResponse {
     match TeamParticipationBusinessLogic::find_or_create_team_participation(


### PR DESCRIPTION
Closes #12

## Summary
Added AuthUser extractor to all protected route handlers across 7 modules to enable future audit logging and user tracking capabilities.

## Changes
Updated all route handlers in the following modules:
- **Event routes**: 5 handlers (create, list, get, update, delete)
- **Country routes**: 3 handlers (list, get, update_status)
- **Team routes**: 7 handlers (create, list, get, update, delete, list_simple, get_detail)
- **Player routes**: 5 handlers (create, list, get, update, delete)
- **Season routes**: 7 handlers (create, list, get, update, delete, list_simple, get_season_team_players)
- **Team Participation routes**: 5 handlers (create, list, get, delete, find_or_create)
- **Player Contract routes**: 4 handlers (create, list, get, delete)

All handlers now extract the authenticated user from request extensions by adding `Extension(_user): Extension<AuthUser>` parameter.

## Testing
- ✅ All tests pass (118 unit tests + integration tests)
- ✅ Code compiles successfully with `cargo check`
- ✅ No errors, only expected warnings about unused AuthUser fields (intentional - for future audit logging)

## Implementation Details
- Each handler now receives the AuthUser from request extensions
- User information is available but not yet used (prefixed with `_` to indicate intentional non-use)
- Maintains compatibility with existing middleware from Task 11
- Ready for future audit logging implementation

## Checklist
- [x] All 7 route modules updated
- [x] AuthUser import added to each module
- [x] All handler signatures updated
- [x] Code compiles without errors
- [x] All tests pass
- [x] Follows project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)