### PR TITLE
security: remove default admin credentials

### DIFF
--- a/backend/migrations/20250713000001_create_users_table.sql
+++ b/backend/migrations/20250713000001_create_users_table.sql
@@ -10,7 +10,3 @@ CREATE TABLE users (
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
-
--- Insert a default admin user (password: "admin123")
-INSERT INTO users (email, password_hash, name) VALUES 
-('admin@example.com', '$2b$12$EnsOQLrapjuJcOIXJJIXIeyHrXpkmxYbColj9UGRvdvJxPok/2Z2y', 'Admin User');


### PR DESCRIPTION
Closes #17

## Summary
Removes the default admin user (admin@example.com) from the users table migration to eliminate a critical security vulnerability. The migration previously inserted hardcoded credentials that could be exploited.

## Changes
- Removed INSERT statement for default admin user from migration `20250713000001_create_users_table.sql`
- Migration now only creates the users table structure without any default data

## Testing
- Migration runs successfully on fresh database
- Verified `users` table is created with correct schema
- Verified no default users exist in fresh database (count = 0)
- All database tables created properly

## Security Impact
This change prevents unauthorized access through default credentials and is part of the OAuth2 Authentication Migration security hardening phase.

## Checklist
- [x] Migration file modified
- [x] Migration runs successfully
- [x] Fresh database has no default users
- [x] No breaking changes to existing functionality
- [x] Follows project security practices

🤖 Generated with [Claude Code](https://claude.com/claude-code)