### PR TITLE
feat: Create Admin CLI Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,22 @@ yarn build
 
 ## 🔐 Authentication
 
-Default login credentials:
-- Email: `admin@hockey.local`
-- Password: `admin123`
+### Creating an Admin User
+
+For security reasons, no default admin credentials are provided. You must create an admin user using the CLI tool:
+
+```bash
+cd backend
+cargo run --bin create_admin
+```
+
+The tool will interactively prompt you for:
+- Email address (must be valid format)
+- Password (minimum 8 characters, hidden input)
+- Password confirmation
+- Name (optional)
+
+The password is securely hashed using bcrypt before being stored in the database.
 
 ## 🌍 Internationalization
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1221,6 +1221,7 @@ dependencies = [
  "clap",
  "dotenvy",
  "jsonwebtoken",
+ "rpassword",
  "schemars",
  "serde",
  "serde_json",
@@ -1753,6 +1754,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,6 +1782,16 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -3,6 +3,10 @@ name = "jura_hockey"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+name = "create_admin"
+path = "src/bin/create_admin.rs"
+
 [dependencies]
 aide = { version = "0.15.0", features = [
 	"axum",
@@ -39,3 +43,4 @@ tower-http = { version = "0.6", features = ["cors"] }
 axum-test = "17.3.0"
 chrono = { version = "0.4", features = ["serde"] }
 async-trait = "0.1"
+rpassword = "7.3"

--- a/backend/src/auth/service.rs
+++ b/backend/src/auth/service.rs
@@ -146,7 +146,6 @@ pub async fn cleanup_expired_tokens(db: &SqlitePool) -> Result<u64, AppError> {
     Ok(result.rows_affected())
 }
 
-#[cfg(test)]
 pub fn hash_password(password: &str) -> Result<String, AppError> {
     hash(password, DEFAULT_COST).map_err(|e| AppError::Internal(e.into()))
 }

--- a/backend/src/bin/create_admin.rs
+++ b/backend/src/bin/create_admin.rs
@@ -1,0 +1,102 @@
+use clap::Parser;
+use dotenvy::dotenv;
+use jura_hockey::{auth::hash_password, config::Config, errors::AppError};
+use sqlx::SqlitePool;
+use std::io::{self, Write};
+
+#[tokio::main]
+async fn main() -> Result<(), AppError> {
+    // Load environment variables from .env file
+    dotenv().ok();
+
+    // Parse config from environment
+    let config = Config::parse();
+
+    // Connect to database
+    let db = SqlitePool::connect(&config.database_url).await?;
+
+    println!("=== Create Admin User ===\n");
+
+    // Prompt for email
+    print!("Email: ");
+    io::stdout().flush().unwrap();
+    let mut email = String::new();
+    io::stdin()
+        .read_line(&mut email)
+        .expect("Failed to read email");
+    let email = email.trim().to_string();
+
+    // Validate email format (basic check)
+    if !email.contains('@') || !email.contains('.') {
+        eprintln!("Error: Invalid email format");
+        std::process::exit(1);
+    }
+
+    // Check if user already exists
+    let existing_user: Option<(i64,)> =
+        sqlx::query_as("SELECT id FROM users WHERE email = ?")
+            .bind(&email)
+            .fetch_optional(&db)
+            .await?;
+
+    if existing_user.is_some() {
+        eprintln!("Error: User with email '{}' already exists", email);
+        std::process::exit(1);
+    }
+
+    // Prompt for password
+    print!("Password: ");
+    io::stdout().flush().unwrap();
+    let password = rpassword::read_password().expect("Failed to read password");
+
+    if password.len() < 8 {
+        eprintln!("Error: Password must be at least 8 characters long");
+        std::process::exit(1);
+    }
+
+    // Prompt for password confirmation
+    print!("Confirm Password: ");
+    io::stdout().flush().unwrap();
+    let password_confirm = rpassword::read_password().expect("Failed to read password");
+
+    if password != password_confirm {
+        eprintln!("Error: Passwords do not match");
+        std::process::exit(1);
+    }
+
+    // Prompt for name
+    print!("Name (optional): ");
+    io::stdout().flush().unwrap();
+    let mut name = String::new();
+    io::stdin()
+        .read_line(&mut name)
+        .expect("Failed to read name");
+    let name = name.trim().to_string();
+    let name = if name.is_empty() { None } else { Some(name) };
+
+    // Hash password
+    println!("\nHashing password...");
+    let password_hash = hash_password(&password)?;
+
+    // Insert user into database
+    println!("Creating admin user...");
+    let result = sqlx::query(
+        "INSERT INTO users (email, name, password_hash) VALUES (?, ?, ?)"
+    )
+    .bind(&email)
+    .bind(&name)
+    .bind(&password_hash)
+    .execute(&db)
+    .await?;
+
+    let user_id = result.last_insert_rowid();
+
+    println!("\n✓ Admin user created successfully!");
+    println!("  ID: {}", user_id);
+    println!("  Email: {}", email);
+    if let Some(n) = name {
+        println!("  Name: {}", n);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #18

## Summary
Implements a secure interactive CLI tool for creating admin users, replacing the need for default credentials in the codebase.

## Changes
- Created `backend/src/bin/create_admin.rs` - Interactive CLI tool
- Added `rpassword` dependency for secure password input
- Made `hash_password` function public in auth service
- Configured binary in `Cargo.toml`
- Updated `README.md` with CLI usage documentation

## Features
- Interactive prompts for email, password, and name
- Email format validation
- Password strength requirement (minimum 8 characters)
- Password confirmation to prevent typos
- Duplicate user detection
- Secure password hashing with bcrypt
- Hidden password input for security

## Testing
- All unit tests pass
- Binary compiles and builds successfully
- Tool validates input and provides clear error messages

## Checklist
- [x] Follows project conventions
- [x] All tests pass
- [x] No compiler/lint warnings
- [x] Documentation updated
- [x] Security best practices followed

## Usage
```bash
cd backend
cargo run --bin create_admin
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)