### PR TITLE
Fix #46: Remove DROP TABLE statements from migrations

### DIFF
--- a/backend/migrations/20250713000001_create_users_table.sql
+++ b/backend/migrations/20250713000001_create_users_table.sql
@@ -1,6 +1,6 @@
 -- Add migration script here
-
-DROP TABLE IF EXISTS users;
+-- Note: SQLx migrations run once and track execution state.
+-- DROP TABLE statements removed to prevent accidental data loss in production.
 
 CREATE TABLE users (
   id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/backend/migrations/20250803120003_create_refresh_tokens_table.sql
+++ b/backend/migrations/20250803120003_create_refresh_tokens_table.sql
@@ -1,6 +1,6 @@
 -- Add migration script here
-
-DROP TABLE IF EXISTS refresh_tokens;
+-- Note: SQLx migrations run once and track execution state.
+-- DROP TABLE statements removed to prevent accidental data loss in production.
 
 CREATE TABLE refresh_tokens (
   id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- Removed `DROP TABLE IF EXISTS` statements from users and refresh_tokens table migrations
- Added explanatory comments documenting why DROP statements are dangerous
- Prevents critical data loss risk in production

## Problem
The migrations contained `DROP TABLE IF EXISTS` statements that would delete all data if migrations were accidentally re-run in production. This posed a critical security risk:
- All user accounts would be deleted
- All authentication sessions would be lost
- Data would be unrecoverable

## Solution
SQLx migrations are designed to run once and track their execution state in a `_sqlx_migrations` table. The DROP statements were unnecessary and dangerous. Removed them and added comments explaining this decision.

## Changes
- `backend/migrations/20250713000001_create_users_table.sql`: Removed DROP TABLE users
- `backend/migrations/20250803120003_create_refresh_tokens_table.sql`: Removed DROP TABLE refresh_tokens

## Test plan
- [x] Removed DROP statements from both migrations
- [x] Added documentation comments explaining the change
- [ ] Test fresh database creation (manual verification recommended)
- [ ] Verify existing databases are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)