### PR TITLE
Fix #48: Use configuration values for JWT token durations in JwtManager

### DIFF
--- a/backend/src/auth/e2e_tests.rs
+++ b/backend/src/auth/e2e_tests.rs
@@ -37,7 +37,8 @@ mod tests {
 
     /// Create a test JWT manager
     fn create_test_jwt_manager() -> JwtManager {
-        JwtManager::new("jwt_private.pem", "jwt_public.pem").expect("Failed to create JwtManager")
+        JwtManager::new("jwt_private.pem", "jwt_public.pem", 15, 7)
+            .expect("Failed to create JwtManager")
     }
 
     /// Create a test API context

--- a/backend/src/auth/middleware.rs
+++ b/backend/src/auth/middleware.rs
@@ -192,7 +192,8 @@ mod tests {
     use crate::auth::jwt::JwtManager;
 
     fn create_test_jwt_manager() -> JwtManager {
-        JwtManager::new("jwt_private.pem", "jwt_public.pem").expect("Failed to create JwtManager")
+        JwtManager::new("jwt_private.pem", "jwt_public.pem", 15, 7)
+            .expect("Failed to create JwtManager")
     }
 
     async fn protected_handler(user: AuthUser) -> String {

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -330,7 +330,8 @@ mod tests {
     }
 
     fn create_test_jwt_manager() -> JwtManager {
-        JwtManager::new("jwt_private.pem", "jwt_public.pem").expect("Failed to create JwtManager")
+        JwtManager::new("jwt_private.pem", "jwt_public.pem", 15, 7)
+            .expect("Failed to create JwtManager")
     }
 
     #[tokio::test]

--- a/backend/src/http.rs
+++ b/backend/src/http.rs
@@ -35,8 +35,12 @@ pub struct ApiContext {
 
 impl ApiContext {
     pub fn new(db: SqlitePool, config: Config) -> Result<Self, Box<dyn std::error::Error>> {
-        let jwt_manager =
-            JwtManager::new(&config.jwt_private_key_path, &config.jwt_public_key_path)?;
+        let jwt_manager = JwtManager::new(
+            &config.jwt_private_key_path,
+            &config.jwt_public_key_path,
+            config.jwt_access_token_duration_minutes,
+            config.jwt_refresh_token_duration_days,
+        )?;
 
         Ok(Self {
             config: Arc::new(config),
@@ -180,8 +184,13 @@ pub async fn serve(config: Config, db: SqlitePool) {
     // It does look nicer than the mess of `move || {}` closures you have to do with Actix-web,
     // which, I suspect, largely has to do with how it manages its own worker threads instead of
     // letting Tokio do it.
-    let jwt_manager = JwtManager::new(&config.jwt_private_key_path, &config.jwt_public_key_path)
-        .expect("Failed to initialize JWT manager");
+    let jwt_manager = JwtManager::new(
+        &config.jwt_private_key_path,
+        &config.jwt_public_key_path,
+        config.jwt_access_token_duration_minutes,
+        config.jwt_refresh_token_duration_days,
+    )
+    .expect("Failed to initialize JWT manager");
 
     let api_context = ApiContext {
         config: Arc::new(config.clone()),


### PR DESCRIPTION
## Summary
- Fixed `JwtManager` to use configuration values instead of hardcoded token durations
- Updated `JwtManager::new()` to accept `access_token_duration_minutes` and `refresh_token_duration_days` parameters
- Updated all initialization sites to pass configuration values from `Config`
- Added comprehensive test to verify custom token durations work correctly

## Changes
### Modified Files
- `backend/src/auth/jwt.rs`: Updated `JwtManager::new()` signature and implementation
- `backend/src/http.rs`: Updated both `JwtManager` initialization sites to use config values
- `backend/src/auth/e2e_tests.rs`: Updated test helper to use default values
- `backend/src/auth/middleware.rs`: Updated test helper to use default values
- `backend/src/auth/mod.rs`: Updated test helper to use default values

### Tests Added
- `test_custom_token_durations`: Verifies that custom token durations (30 min access, 14 days refresh) are properly applied to generated tokens

## Test Results
- ✅ All 136 unit tests pass
- ✅ All 66 integration tests pass
- ✅ Build completes successfully
- ✅ New test verifies custom token durations work correctly

## Verification
The fix ensures that:
1. Configuration values `jwt_access_token_duration_minutes` and `jwt_refresh_token_duration_days` are now properly used
2. Token expiry times match the configured durations
3. Environment-specific token durations are now possible
4. No breaking changes to existing tests or functionality

## Related Issues
Fixes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)