### PR TITLE
feat: implement internationalization (i18n) setup with fluent-rs

### DIFF
--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -42,7 +42,7 @@ time = "0.3"
 fluent = "0.16"
 fluent-bundle = "0.15"
 intl-memoizer = "0.5"
-unic-langid = "0.9"
+unic-langid = { version = "0.9", features = ["macros"] }
 
 # Error handling
 anyhow = "1.0"

--- a/frontend/src/app_state.rs
+++ b/frontend/src/app_state.rs
@@ -1,15 +1,22 @@
 use sqlx::SqlitePool;
+use std::sync::Arc;
 
 use crate::auth::SessionStore;
+use crate::i18n::I18n;
 
 #[derive(Clone)]
 pub struct AppState {
     pub db: SqlitePool,
     pub sessions: SessionStore,
+    pub i18n: Arc<I18n>,
 }
 
 impl AppState {
     pub fn new(db: SqlitePool, sessions: SessionStore) -> Self {
-        Self { db, sessions }
+        Self {
+            db,
+            sessions,
+            i18n: Arc::new(I18n::new()),
+        }
     }
 }

--- a/frontend/src/i18n/messages/cs.ftl
+++ b/frontend/src/i18n/messages/cs.ftl
@@ -1,0 +1,122 @@
+# Navigation
+nav-dashboard = Přehled
+nav-teams = Týmy
+nav-players = Hráči
+nav-events = Události
+nav-seasons = Sezóny
+nav-matches = Zápasy
+nav-management = Správa
+
+# User menu
+user-logout = Odhlásit se
+user-language = Jazyk
+user-signed-in-as = Přihlášen jako
+
+# Dashboard
+dashboard-title = Dashboard
+dashboard-subtitle = Vítejte v přehledu vašeho systému správy hokeje
+dashboard-stats-total-teams = Celkem týmů
+dashboard-stats-active-players = Aktivních hráčů
+dashboard-stats-ongoing-seasons = Probíhajících sezón
+dashboard-stats-total-events = Celkem událostí
+dashboard-recent-activity = Nedávná aktivita
+dashboard-quick-actions = Rychlé akce
+
+# Teams
+teams-title = Týmy
+teams-description = Správa a zobrazení všech týmů v systému.
+teams-search-placeholder = Hledat týmy...
+teams-add = Přidat tým
+teams-edit = Upravit tým
+teams-delete = Smazat tým
+teams-empty-title = Nebyly nalezeny žádné týmy
+teams-empty-message = Žádné týmy neodpovídají vašim kritériím.
+teams-create = Vytvořit tým
+teams-name = Název týmu
+teams-country = Země
+
+# Players
+players-title = Hráči
+players-description = Správa a zobrazení všech hráčů v systému.
+players-search-placeholder = Hledat hráče...
+
+# Events
+events-title = Události
+events-description = Správa a zobrazení všech hokejových událostí a turnajů.
+events-search-placeholder = Hledat události...
+
+# Seasons
+seasons-title = Sezóny
+seasons-description = Správa a zobrazení všech sezón v systému.
+seasons-search-placeholder = Hledat sezóny...
+
+# Matches
+matches-title = Zápasy
+matches-description = Správa a zobrazení všech hokejových zápasů a her.
+matches-search-placeholder = Hledat zápasy...
+matches-filter-all-seasons = Všechny sezóny
+matches-filter-all-teams = Všechny týmy
+matches-filter-all-statuses = Všechny stavy
+matches-status-scheduled = Naplánovaný
+matches-status-in-progress = Probíhá
+matches-status-finished = Ukončený
+matches-status-cancelled = Zrušený
+
+# Management
+management-title = Správa
+management-description = Konfigurace a správa systémových nastavení, zemí a administrativních možností.
+management-countries-title = Země
+management-countries-search-placeholder = Hledat země...
+management-countries-table-country = Země
+management-countries-table-code = Kód
+management-countries-table-ioc-code = Olympijský kód
+management-countries-table-iso-code = ISO 3136 kód
+management-countries-table-iihf-member = IIHF člen
+management-countries-table-enabled = Povoleno
+management-countries-empty-title = Nebyly nalezeny žádné země
+management-countries-empty-search = Zkuste upravit vyhledávací podmínky.
+management-countries-empty-message = Zde jsou zobrazeny všechny země ze systémové databáze.
+management-loading = Načítání
+
+# Sign In
+signin-title = Přihlaste se do svého účtu
+signin-subtitle = Přístup do systému správy hokejové databáze
+signin-email = E-mailová adresa
+signin-password = Heslo
+signin-button = Přihlásit se
+signin-signing-in = Přihlašování...
+signin-error-invalid-credentials = Neplatný e-mail nebo heslo
+signin-error-general = Něco se pokazilo. Zkuste to prosím znovu.
+
+# Common
+common-save = Uložit
+common-cancel = Zrušit
+common-delete = Smazat
+common-edit = Upravit
+common-create = Vytvořit
+common-search = Hledat
+common-loading = Načítání...
+common-error = Chyba
+common-success = Úspěch
+common-yes = Ano
+common-no = Ne
+common-confirm = Potvrdit
+common-close = Zavřít
+common-back = Zpět
+common-next = Další
+common-previous = Předchozí
+common-name = Název
+common-description = Popis
+common-actions = Akce
+
+# Validation
+validation-required = Toto pole je povinné
+validation-email-invalid = Zadejte prosím platnou e-mailovou adresu
+validation-name-required = Název je povinný
+validation-country-required = Země je povinná
+
+# Errors
+error-not-found = Nenalezeno
+error-unauthorized = Neautorizováno
+error-server-error = Chyba serveru
+error-unknown = Nastala neznámá chyba

--- a/frontend/src/i18n/messages/en.ftl
+++ b/frontend/src/i18n/messages/en.ftl
@@ -1,0 +1,122 @@
+# Navigation
+nav-dashboard = Dashboard
+nav-teams = Teams
+nav-players = Players
+nav-events = Events
+nav-seasons = Seasons
+nav-matches = Matches
+nav-management = Management
+
+# User menu
+user-logout = Logout
+user-language = Language
+user-signed-in-as = Signed in as
+
+# Dashboard
+dashboard-title = Dashboard
+dashboard-subtitle = Welcome to your hockey management system overview
+dashboard-stats-total-teams = Total Teams
+dashboard-stats-active-players = Active Players
+dashboard-stats-ongoing-seasons = Ongoing Seasons
+dashboard-stats-total-events = Total Events
+dashboard-recent-activity = Recent Activity
+dashboard-quick-actions = Quick Actions
+
+# Teams
+teams-title = Teams
+teams-description = Manage and view all teams in the system.
+teams-search-placeholder = Search teams...
+teams-add = Add Team
+teams-edit = Edit Team
+teams-delete = Delete Team
+teams-empty-title = No teams found
+teams-empty-message = No teams match your search criteria.
+teams-create = Create Team
+teams-name = Team Name
+teams-country = Country
+
+# Players
+players-title = Players
+players-description = Manage and view all players in the system.
+players-search-placeholder = Search players...
+
+# Events
+events-title = Events
+events-description = Manage and view all hockey events and tournaments.
+events-search-placeholder = Search events...
+
+# Seasons
+seasons-title = Seasons
+seasons-description = Manage and view all seasons in the system.
+seasons-search-placeholder = Search seasons...
+
+# Matches
+matches-title = Matches
+matches-description = Manage and view all hockey matches and games.
+matches-search-placeholder = Search matches...
+matches-filter-all-seasons = All Seasons
+matches-filter-all-teams = All Teams
+matches-filter-all-statuses = All Statuses
+matches-status-scheduled = Scheduled
+matches-status-in-progress = In Progress
+matches-status-finished = Finished
+matches-status-cancelled = Cancelled
+
+# Management
+management-title = Management
+management-description = Configure and manage system settings, countries, and administrative options.
+management-countries-title = Countries
+management-countries-search-placeholder = Search countries...
+management-countries-table-country = Country
+management-countries-table-code = Code
+management-countries-table-ioc-code = Olympic code
+management-countries-table-iso-code = ISO 3136 Code
+management-countries-table-iihf-member = IIHF Member
+management-countries-table-enabled = Enabled
+management-countries-empty-title = No countries found
+management-countries-empty-search = Try adjusting your search terms.
+management-countries-empty-message = All countries from the system database are shown here.
+management-loading = Loading
+
+# Sign In
+signin-title = Sign in to your account
+signin-subtitle = Access the Hockey Database Management System
+signin-email = Email address
+signin-password = Password
+signin-button = Sign in
+signin-signing-in = Signing in...
+signin-error-invalid-credentials = Invalid email or password
+signin-error-general = Something went wrong. Please try again.
+
+# Common
+common-save = Save
+common-cancel = Cancel
+common-delete = Delete
+common-edit = Edit
+common-create = Create
+common-search = Search
+common-loading = Loading...
+common-error = Error
+common-success = Success
+common-yes = Yes
+common-no = No
+common-confirm = Confirm
+common-close = Close
+common-back = Back
+common-next = Next
+common-previous = Previous
+common-name = Name
+common-description = Description
+common-actions = Actions
+
+# Validation
+validation-required = This field is required
+validation-email-invalid = Please enter a valid email address
+validation-name-required = Name is required
+validation-country-required = Country is required
+
+# Errors
+error-not-found = Not found
+error-unauthorized = Unauthorized
+error-server-error = Server error
+error-unknown = An unknown error occurred

--- a/frontend/src/i18n/mod.rs
+++ b/frontend/src/i18n/mod.rs
@@ -1,9 +1,12 @@
-// Internationalization module
-// For now, we'll use simple string constants
-// TODO: Implement fluent-rs integration for proper i18n
+use fluent::{FluentArgs, FluentBundle, FluentResource};
+use unic_langid::{langid, LanguageIdentifier};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+const EN_MESSAGES: &str = include_str!("messages/en.ftl");
+const CS_MESSAGES: &str = include_str!("messages/cs.ftl");
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum Locale {
+    #[default]
     English,
     Czech,
 }
@@ -17,7 +20,6 @@ impl Locale {
         }
     }
 
-    #[allow(dead_code)]
     pub fn code(&self) -> &'static str {
         match self {
             Locale::English => "en",
@@ -32,85 +34,121 @@ impl Locale {
             Locale::Czech => "Čeština",
         }
     }
-}
 
-pub struct Translations {
-    pub locale: Locale,
-}
-
-impl Translations {
-    pub fn new(locale: Locale) -> Self {
-        Self { locale }
-    }
-
-    // Navigation items
-    pub fn nav_dashboard(&self) -> &'static str {
-        match self.locale {
-            Locale::English => "Dashboard",
-            Locale::Czech => "Přehled",
+    fn lang_id(&self) -> LanguageIdentifier {
+        match self {
+            Locale::English => langid!("en"),
+            Locale::Czech => langid!("cs"),
         }
     }
 
-    pub fn nav_teams(&self) -> &'static str {
-        match self.locale {
-            Locale::English => "Teams",
-            Locale::Czech => "Týmy",
-        }
-    }
-
-    pub fn nav_players(&self) -> &'static str {
-        match self.locale {
-            Locale::English => "Players",
-            Locale::Czech => "Hráči",
-        }
-    }
-
-    pub fn nav_events(&self) -> &'static str {
-        match self.locale {
-            Locale::English => "Events",
-            Locale::Czech => "Události",
-        }
-    }
-
-    pub fn nav_seasons(&self) -> &'static str {
-        match self.locale {
-            Locale::English => "Seasons",
-            Locale::Czech => "Sezóny",
-        }
-    }
-
-    pub fn nav_matches(&self) -> &'static str {
-        match self.locale {
-            Locale::English => "Matches",
-            Locale::Czech => "Zápasy",
-        }
-    }
-
-    pub fn nav_management(&self) -> &'static str {
-        match self.locale {
-            Locale::English => "Management",
-            Locale::Czech => "Správa",
-        }
-    }
-
-    // User menu
-    pub fn logout(&self) -> &'static str {
-        match self.locale {
-            Locale::English => "Logout",
-            Locale::Czech => "Odhlásit se",
-        }
-    }
-
-    pub fn language(&self) -> &'static str {
-        match self.locale {
-            Locale::English => "Language",
-            Locale::Czech => "Jazyk",
+    fn messages(&self) -> &'static str {
+        match self {
+            Locale::English => EN_MESSAGES,
+            Locale::Czech => CS_MESSAGES,
         }
     }
 }
 
-impl Default for Translations {
+
+// FluentBundle with IntlLangMemoizer is not Send because it uses RefCell internally
+// We create bundles on-demand per translation instead of caching them
+pub struct I18n;
+
+impl I18n {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn create_bundle(locale: Locale) -> FluentBundle<FluentResource> {
+        let resource = FluentResource::try_new(locale.messages().to_string())
+            .expect("Failed to parse Fluent resource");
+
+        let mut bundle = FluentBundle::new(vec![locale.lang_id()]);
+        bundle
+            .add_resource(resource)
+            .expect("Failed to add resource to bundle");
+
+        bundle
+    }
+
+    pub fn translate(&self, locale: Locale, key: &str) -> String {
+        self.translate_with_args(locale, key, None)
+    }
+
+    pub fn translate_with_args(
+        &self,
+        locale: Locale,
+        key: &str,
+        args: Option<&FluentArgs>,
+    ) -> String {
+        let bundle = Self::create_bundle(locale);
+
+        let message = bundle.get_message(key).unwrap_or_else(|| {
+            panic!(
+                "Message '{}' not found in {} locale",
+                key,
+                locale.code()
+            )
+        });
+
+        let pattern = message.value().unwrap_or_else(|| {
+            panic!(
+                "Message '{}' has no value in {} locale",
+                key,
+                locale.code()
+            )
+        });
+
+        let mut errors = vec![];
+        let value = bundle.format_pattern(pattern, args, &mut errors);
+
+        if !errors.is_empty() {
+            eprintln!("Translation errors for key '{}': {:?}", key, errors);
+        }
+
+        value.to_string()
+    }
+}
+
+impl Default for I18n {
     fn default() -> Self {
-        Self::new(Locale::English)
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_locale_from_code() {
+        assert_eq!(Locale::from_code("en"), Locale::English);
+        assert_eq!(Locale::from_code("cs"), Locale::Czech);
+        assert_eq!(Locale::from_code("cz"), Locale::Czech);
+        assert_eq!(Locale::from_code("unknown"), Locale::English);
+    }
+
+    #[test]
+    fn test_locale_code() {
+        assert_eq!(Locale::English.code(), "en");
+        assert_eq!(Locale::Czech.code(), "cs");
+    }
+
+    #[test]
+    fn test_i18n_translate_english() {
+        let i18n = I18n::new();
+        assert_eq!(
+            i18n.translate(Locale::English, "nav-dashboard"),
+            "Dashboard"
+        );
+        assert_eq!(i18n.translate(Locale::English, "nav-teams"), "Teams");
+    }
+
+    #[test]
+    fn test_i18n_translate_czech() {
+        let i18n = I18n::new();
+        assert_eq!(i18n.translate(Locale::Czech, "nav-dashboard"), "Přehled");
+        assert_eq!(i18n.translate(Locale::Czech, "nav-teams"), "Týmy");
     }
 }

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -8,7 +8,7 @@ mod views;
 
 use app_state::AppState;
 use axum::{
-    extract::Request,
+    extract::{Request, State},
     middleware,
     response::Html,
     routing::{get, post},
@@ -115,7 +115,7 @@ async fn main() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-async fn root_handler(request: Request) -> Html<String> {
+async fn root_handler(State(state): State<AppState>, request: Request) -> Html<String> {
     // Extract session from request extensions (added by require_auth middleware)
     let session = request
         .extensions()
@@ -128,7 +128,7 @@ async fn root_handler(request: Request) -> Html<String> {
     let locale = Locale::English;
 
     let content = dashboard_page();
-    let html = admin_layout("Dashboard", &session, "/", locale, content);
+    let html = admin_layout("Dashboard", &session, "/", &state.i18n, locale, content);
 
     Html(html.into_string())
 }

--- a/frontend/src/routes/events.rs
+++ b/frontend/src/routes/events.rs
@@ -68,6 +68,7 @@ pub async fn events_list_get(
                     "Events",
                     &session,
                     "/events",
+                    &state.i18n,
                     locale,
                     crate::views::components::error::error_message("Failed to load events"),
                 )
@@ -80,7 +81,7 @@ pub async fn events_list_get(
     let countries = events::get_countries(&state.db).await.unwrap_or_default();
 
     let content = events_page(&result, &filters, &countries);
-    Html(admin_layout("Events", &session, "/events", locale, content).into_string())
+    Html(admin_layout("Events", &session, "/events", &state.i18n, locale, content).into_string())
 }
 
 /// GET /events/list - HTMX endpoint for table updates

--- a/frontend/src/routes/matches.rs
+++ b/frontend/src/routes/matches.rs
@@ -27,6 +27,7 @@ pub async fn match_detail_get(
                     "Match Not Found",
                     &session,
                     "/matches",
+                    &state.i18n,
                     locale,
                     crate::views::components::error::error_message("Match not found"),
                 )
@@ -40,6 +41,7 @@ pub async fn match_detail_get(
                     "Error",
                     &session,
                     "/matches",
+                    &state.i18n,
                     locale,
                     crate::views::components::error::error_message("Failed to load match detail"),
                 )
@@ -49,7 +51,17 @@ pub async fn match_detail_get(
     };
 
     let content = match_detail_page(&match_detail);
-    Html(admin_layout("Match Detail", &session, "/matches", locale, content).into_string())
+    Html(
+        admin_layout(
+            "Match Detail",
+            &session,
+            "/matches",
+            &state.i18n,
+            locale,
+            content,
+        )
+        .into_string(),
+    )
 }
 
 /// POST /matches/{id}/delete - Delete match

--- a/frontend/src/views/components/sidebar.rs
+++ b/frontend/src/views/components/sidebar.rs
@@ -1,7 +1,7 @@
 use maud::{html, Markup};
 
 use crate::auth::Session;
-use crate::i18n::Translations;
+use crate::i18n::{I18n, Locale};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NavItem {
@@ -28,15 +28,19 @@ impl NavItem {
     }
 }
 
-pub fn sidebar(session: &Session, current_path: &str, t: &Translations) -> Markup {
+pub fn sidebar(session: &Session, current_path: &str, i18n: &I18n, locale: Locale) -> Markup {
     let nav_items = vec![
-        NavItem::new("/", t.nav_dashboard(), "📊"),
-        NavItem::new("/teams", t.nav_teams(), "🏒"),
-        NavItem::new("/players", t.nav_players(), "👤"),
-        NavItem::new("/events", t.nav_events(), "🏆"),
-        NavItem::new("/seasons", t.nav_seasons(), "📅"),
-        NavItem::new("/matches", t.nav_matches(), "🎯"),
-        NavItem::new("/management", t.nav_management(), "⚙️"),
+        NavItem::new("/", i18n.translate(locale, "nav-dashboard"), "📊"),
+        NavItem::new("/teams", i18n.translate(locale, "nav-teams"), "🏒"),
+        NavItem::new("/players", i18n.translate(locale, "nav-players"), "👤"),
+        NavItem::new("/events", i18n.translate(locale, "nav-events"), "🏆"),
+        NavItem::new("/seasons", i18n.translate(locale, "nav-seasons"), "📅"),
+        NavItem::new("/matches", i18n.translate(locale, "nav-matches"), "🎯"),
+        NavItem::new(
+            "/management",
+            i18n.translate(locale, "nav-management"),
+            "⚙️",
+        ),
     ];
 
     html! {
@@ -56,8 +60,8 @@ pub fn sidebar(session: &Session, current_path: &str, t: &Translations) -> Marku
             // User info and controls at bottom
             div class="sidebar-footer" {
                 (user_info(session))
-                (locale_switcher(t))
-                (logout_button(t))
+                (locale_switcher(i18n, locale))
+                (logout_button(i18n, locale))
             }
         }
     }
@@ -92,24 +96,24 @@ fn user_info(session: &Session) -> Markup {
     }
 }
 
-fn locale_switcher(t: &Translations) -> Markup {
+fn locale_switcher(i18n: &I18n, locale: Locale) -> Markup {
     html! {
         div class="locale-switcher" {
-            label for="locale-select" class="locale-label" { (t.language()) }
+            label for="locale-select" class="locale-label" { (i18n.translate(locale, "user-language")) }
             select id="locale-select" class="locale-select" {
-                option value="en" selected[t.locale == crate::i18n::Locale::English] { "English" }
-                option value="cs" selected[t.locale == crate::i18n::Locale::Czech] { "Čeština" }
+                option value="en" selected[locale == Locale::English] { "English" }
+                option value="cs" selected[locale == Locale::Czech] { "Čeština" }
             }
         }
     }
 }
 
-fn logout_button(t: &Translations) -> Markup {
+fn logout_button(i18n: &I18n, locale: Locale) -> Markup {
     html! {
         form method="POST" action="/auth/logout" class="logout-form" {
             button type="submit" class="logout-button" {
                 span class="nav-icon" { "🚪" }
-                span { (t.logout()) }
+                span { (i18n.translate(locale, "user-logout")) }
             }
         }
     }

--- a/frontend/src/views/layout.rs
+++ b/frontend/src/views/layout.rs
@@ -2,7 +2,7 @@ use maud::{html, Markup, DOCTYPE};
 
 use super::components::sidebar;
 use crate::auth::Session;
-use crate::i18n::{Locale, Translations};
+use crate::i18n::{I18n, Locale};
 
 pub fn base_layout(title: &str, content: Markup) -> Markup {
     html! {
@@ -26,16 +26,15 @@ pub fn admin_layout(
     title: &str,
     session: &Session,
     current_path: &str,
+    i18n: &I18n,
     locale: Locale,
     content: Markup,
 ) -> Markup {
-    let t = Translations::new(locale);
-
     base_layout(
         title,
         html! {
             div class="app-layout" {
-                (sidebar(session, current_path, &t))
+                (sidebar(session, current_path, i18n, locale))
                 main class="main-content" {
                     div class="content-wrapper" {
                         (content)


### PR DESCRIPTION
Closes #67

## Summary
- Set up fluent-rs for Czech/English support
- Created Fluent message files with comprehensive translations
- Implemented thread-safe I18n struct with on-demand bundle creation
- Integrated I18n into application state and updated all routes
- Added comprehensive tests

## Changes
- Added `unic-langid` with macros feature to Cargo.toml
- Created `frontend/src/i18n/messages/en.ftl` with English translations
- Created `frontend/src/i18n/messages/cs.ftl` with Czech translations
- Rewrote I18n module to use fluent-rs instead of static translations
- Updated `AppState` to include `Arc<I18n>`
- Updated `admin_layout`, `sidebar`, and route handlers to use I18n
- Added tests for locale handling and translation functionality

## Technical Details
The implementation creates Fluent bundles on-demand per translation request rather than caching them. This approach avoids thread-safety issues with `IntlLangMemoizer`, which uses `RefCell` internally and is not `Send`. While this has a small performance overhead, it keeps the implementation simple and thread-safe for the Axum async runtime.

## Testing
- All existing tests pass
- New tests added for i18n functionality
- Verified English and Czech translations work correctly
- Clippy and formatting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)