### PR TITLE
feat: implement players management with reusable table component

### DIFF
--- a/frontend/src/common/mod.rs
+++ b/frontend/src/common/mod.rs
@@ -1,0 +1,1 @@
+pub mod pagination;

--- a/frontend/src/common/pagination.rs
+++ b/frontend/src/common/pagination.rs
@@ -1,0 +1,73 @@
+/// Generic paginated result wrapper
+#[derive(Debug, Clone)]
+pub struct PagedResult<T> {
+    pub items: Vec<T>,
+    pub total: usize,
+    pub page: usize,
+    pub page_size: usize,
+    pub total_pages: usize,
+    pub has_next: bool,
+    pub has_previous: bool,
+}
+
+impl<T> PagedResult<T> {
+    pub fn new(items: Vec<T>, total: usize, page: usize, page_size: usize) -> Self {
+        let total_pages = total.div_ceil(page_size);
+        let has_next = page < total_pages;
+        let has_previous = page > 1;
+
+        Self {
+            items,
+            total,
+            page,
+            page_size,
+            total_pages,
+            has_next,
+            has_previous,
+        }
+    }
+}
+
+/// Base trait for sortable fields
+pub trait SortableField {
+    fn from_str(s: &str) -> Self;
+    fn to_sql(&self) -> &'static str;
+    fn as_str(&self) -> &'static str;
+}
+
+/// Sort order (ascending/descending)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SortOrder {
+    Asc,
+    Desc,
+}
+
+impl SortOrder {
+    pub fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "desc" => Self::Desc,
+            _ => Self::Asc,
+        }
+    }
+
+    pub fn to_sql(&self) -> &'static str {
+        match self {
+            Self::Asc => "ASC",
+            Self::Desc => "DESC",
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Asc => "asc",
+            Self::Desc => "desc",
+        }
+    }
+
+    pub fn toggle(&self) -> Self {
+        match self {
+            Self::Asc => Self::Desc,
+            Self::Desc => Self::Asc,
+        }
+    }
+}

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -1,5 +1,6 @@
 mod app_state;
 mod auth;
+mod common;
 mod config;
 mod i18n;
 mod routes;
@@ -97,6 +98,13 @@ async fn main() -> Result<(), anyhow::Error> {
         .route("/teams/:id/edit", get(routes::teams::team_edit_form))
         .route("/teams/:id", post(routes::teams::team_update))
         .route("/teams/:id/delete", post(routes::teams::team_delete))
+        .route("/players", get(routes::players::players_get))
+        .route("/players/list", get(routes::players::players_list_partial))
+        .route("/players/new", get(routes::players::player_create_form))
+        .route("/players", post(routes::players::player_create))
+        .route("/players/:id/edit", get(routes::players::player_edit_form))
+        .route("/players/:id", post(routes::players::player_update))
+        .route("/players/:id/delete", post(routes::players::player_delete))
         .route("/matches/:id", get(routes::matches::match_detail))
         .route("/matches/:id/delete", post(routes::matches::match_delete))
         .layer(middleware::from_fn_with_state(state.clone(), require_auth));

--- a/frontend/src/routes/mod.rs
+++ b/frontend/src/routes/mod.rs
@@ -2,4 +2,5 @@ pub mod auth;
 pub mod countries;
 pub mod events;
 pub mod matches;
+pub mod players;
 pub mod teams;

--- a/frontend/src/routes/players.rs
+++ b/frontend/src/routes/players.rs
@@ -1,0 +1,319 @@
+use axum::{
+    extract::{Path, Query, State},
+    response::{Html, IntoResponse},
+    Extension, Form,
+};
+use serde::Deserialize;
+
+use crate::app_state::AppState;
+use crate::auth::Session;
+use crate::i18n::Locale;
+use crate::service::players::{
+    self, CreatePlayerEntity, PlayerFilters, SortField, SortOrder, UpdatePlayerEntity,
+};
+use crate::views::{
+    layout::admin_layout,
+    pages::players::{player_create_modal, player_edit_modal, player_list_content, players_page},
+};
+
+#[derive(Debug, Deserialize)]
+pub struct PlayersQuery {
+    #[serde(default = "default_page")]
+    page: usize,
+    #[serde(default = "default_page_size")]
+    page_size: usize,
+    #[serde(default, deserialize_with = "crate::utils::empty_string_as_none")]
+    name: Option<String>,
+    #[serde(default, deserialize_with = "crate::utils::empty_string_as_none_i64")]
+    country_id: Option<i64>,
+    #[serde(default = "default_sort")]
+    sort: String,
+    #[serde(default = "default_sort_order")]
+    order: String,
+}
+
+fn default_page() -> usize {
+    1
+}
+
+fn default_page_size() -> usize {
+    20
+}
+
+fn default_sort() -> String {
+    "name".to_string()
+}
+
+fn default_sort_order() -> String {
+    "asc".to_string()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreatePlayerForm {
+    name: String,
+    country_id: i64,
+    photo_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdatePlayerForm {
+    name: String,
+    country_id: i64,
+    photo_path: Option<String>,
+}
+
+/// GET /players - Players list page
+pub async fn players_get(
+    Extension(session): Extension<Session>,
+    State(state): State<AppState>,
+    Query(query): Query<PlayersQuery>,
+) -> impl IntoResponse {
+    let locale = Locale::English;
+
+    // Build filters
+    let filters = PlayerFilters {
+        name: query.name.clone(),
+        country_id: query.country_id,
+    };
+
+    // Parse sorting
+    let sort_field = SortField::from_str(&query.sort);
+    let sort_order = SortOrder::from_str(&query.order);
+
+    // Get players
+    let result = match players::get_players(
+        &state.db,
+        &filters,
+        &sort_field,
+        &sort_order,
+        query.page,
+        query.page_size,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::error!("Failed to fetch players: {}", e);
+            return Html(
+                admin_layout(
+                    "Players",
+                    &session,
+                    "/players",
+                    &state.i18n,
+                    locale,
+                    crate::views::components::error::error_message("Failed to load players"),
+                )
+                .into_string(),
+            );
+        }
+    };
+
+    // Get countries for filter
+    let countries = players::get_countries(&state.db).await.unwrap_or_default();
+
+    let content = players_page(&result, &filters, &sort_field, &sort_order, &countries);
+    Html(admin_layout("Players", &session, "/players", &state.i18n, locale, content).into_string())
+}
+
+/// GET /players/list - HTMX endpoint for table updates
+pub async fn players_list_partial(
+    State(state): State<AppState>,
+    Query(query): Query<PlayersQuery>,
+) -> impl IntoResponse {
+    let filters = PlayerFilters {
+        name: query.name.clone(),
+        country_id: query.country_id,
+    };
+
+    // Parse sorting
+    let sort_field = SortField::from_str(&query.sort);
+    let sort_order = SortOrder::from_str(&query.order);
+
+    let result = match players::get_players(
+        &state.db,
+        &filters,
+        &sort_field,
+        &sort_order,
+        query.page,
+        query.page_size,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::error!("Failed to fetch players: {}", e);
+            return Html(
+                crate::views::components::error::error_message("Failed to load players")
+                    .into_string(),
+            );
+        }
+    };
+
+    Html(player_list_content(&result, &filters, &sort_field, &sort_order).into_string())
+}
+
+/// GET /players/new - Show create modal
+pub async fn player_create_form(State(state): State<AppState>) -> impl IntoResponse {
+    let countries = players::get_countries(&state.db).await.unwrap_or_default();
+    Html(player_create_modal(None, &countries).into_string())
+}
+
+/// POST /players - Create new player
+pub async fn player_create(
+    State(state): State<AppState>,
+    Form(form): Form<CreatePlayerForm>,
+) -> impl IntoResponse {
+    // Get countries for form re-render on error
+    let countries = players::get_countries(&state.db).await.unwrap_or_default();
+
+    // Validation
+    let name = form.name.trim();
+    if name.is_empty() {
+        return Html(player_create_modal(Some("Player name cannot be empty"), &countries).into_string());
+    }
+
+    if name.len() > 255 {
+        return Html(
+            player_create_modal(
+                Some("Player name cannot exceed 255 characters"),
+                &countries,
+            )
+            .into_string(),
+        );
+    }
+
+    // Create player
+    match players::create_player(
+        &state.db,
+        CreatePlayerEntity {
+            name: name.to_string(),
+            country_id: form.country_id,
+            photo_path: form.photo_path,
+        },
+    )
+    .await
+    {
+        Ok(_) => {
+            // Return HTMX response to close modal and reload table
+            Html("<div hx-get=\"/players/list\" hx-target=\"#players-table\" hx-trigger=\"load\" hx-swap=\"outerHTML\"></div>".to_string())
+        }
+        Err(e) => {
+            tracing::error!("Failed to create player: {}", e);
+            Html(player_create_modal(Some("Failed to create player"), &countries).into_string())
+        }
+    }
+}
+
+/// GET /players/{id}/edit - Show edit modal
+pub async fn player_edit_form(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> impl IntoResponse {
+    let countries = players::get_countries(&state.db).await.unwrap_or_default();
+
+    let player = match players::get_player_by_id(&state.db, id).await {
+        Ok(Some(player)) => player,
+        Ok(None) => {
+            return Html(
+                crate::views::components::error::error_message("Player not found").into_string(),
+            );
+        }
+        Err(e) => {
+            tracing::error!("Failed to fetch player: {}", e);
+            return Html(
+                crate::views::components::error::error_message("Failed to load player")
+                    .into_string(),
+            );
+        }
+    };
+
+    Html(player_edit_modal(&player, None, &countries).into_string())
+}
+
+/// POST /players/{id} - Update player
+pub async fn player_update(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    Form(form): Form<UpdatePlayerForm>,
+) -> impl IntoResponse {
+    let countries = players::get_countries(&state.db).await.unwrap_or_default();
+
+    // Validation
+    let name = form.name.trim();
+    if name.is_empty() {
+        let player = players::get_player_by_id(&state.db, id).await.ok().flatten();
+        return Html(
+            player_edit_modal(
+                &player.unwrap(),
+                Some("Player name cannot be empty"),
+                &countries,
+            )
+            .into_string(),
+        );
+    }
+
+    if name.len() > 255 {
+        let player = players::get_player_by_id(&state.db, id).await.ok().flatten();
+        return Html(
+            player_edit_modal(
+                &player.unwrap(),
+                Some("Player name cannot exceed 255 characters"),
+                &countries,
+            )
+            .into_string(),
+        );
+    }
+
+    // Update player
+    match players::update_player(
+        &state.db,
+        id,
+        UpdatePlayerEntity {
+            name: name.to_string(),
+            country_id: form.country_id,
+            photo_path: form.photo_path,
+        },
+    )
+    .await
+    {
+        Ok(true) => {
+            // Return HTMX response to close modal and reload table
+            Html("<div hx-get=\"/players/list\" hx-target=\"#players-table\" hx-trigger=\"load\" hx-swap=\"outerHTML\"></div>".to_string())
+        }
+        Ok(false) => {
+            let player = players::get_player_by_id(&state.db, id).await.ok().flatten();
+            Html(player_edit_modal(&player.unwrap(), Some("Player not found"), &countries).into_string())
+        }
+        Err(e) => {
+            tracing::error!("Failed to update player: {}", e);
+            let player = players::get_player_by_id(&state.db, id).await.ok().flatten();
+            Html(
+                player_edit_modal(&player.unwrap(), Some("Failed to update player"), &countries)
+                    .into_string(),
+            )
+        }
+    }
+}
+
+/// POST /players/{id}/delete - Delete player
+pub async fn player_delete(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> impl IntoResponse {
+    match players::delete_player(&state.db, id).await {
+        Ok(true) => {
+            // Return HTMX response to reload table
+            Html("<div hx-get=\"/players/list\" hx-target=\"#players-table\" hx-trigger=\"load\" hx-swap=\"outerHTML\"></div>".to_string())
+        }
+        Ok(false) => Html(
+            crate::views::components::error::error_message("Player not found").into_string(),
+        ),
+        Err(e) => {
+            tracing::error!("Failed to delete player: {}", e);
+            Html(
+                crate::views::components::error::error_message("Failed to delete player")
+                    .into_string(),
+            )
+        }
+    }
+}

--- a/frontend/src/service/mod.rs
+++ b/frontend/src/service/mod.rs
@@ -1,4 +1,5 @@
 pub mod countries;
 pub mod events;
 pub mod matches;
+pub mod players;
 pub mod teams;

--- a/frontend/src/service/players.rs
+++ b/frontend/src/service/players.rs
@@ -1,0 +1,217 @@
+use sqlx::{Row, SqlitePool};
+
+// Re-export common pagination types for convenience
+pub use crate::common::pagination::{PagedResult, SortOrder};
+
+#[derive(Debug, Clone)]
+pub struct PlayerEntity {
+    pub id: i64,
+    pub name: String,
+    pub country_id: i64,
+    pub country_name: String,
+    pub country_iso2_code: String,
+    pub photo_path: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreatePlayerEntity {
+    pub name: String,
+    pub country_id: i64,
+    pub photo_path: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdatePlayerEntity {
+    pub name: String,
+    pub country_id: i64,
+    pub photo_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PlayerFilters {
+    pub name: Option<String>,
+    pub country_id: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SortField {
+    Id,
+    Name,
+    Country,
+}
+
+impl SortField {
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "id" => Self::Id,
+            "name" => Self::Name,
+            "country" => Self::Country,
+            _ => Self::Name, // Default
+        }
+    }
+
+    pub fn to_sql(&self) -> &'static str {
+        match self {
+            Self::Id => "p.id",
+            Self::Name => "p.name",
+            Self::Country => "c.name",
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Id => "id",
+            Self::Name => "name",
+            Self::Country => "country",
+        }
+    }
+}
+
+/// Create a new player
+pub async fn create_player(
+    db: &SqlitePool,
+    player: CreatePlayerEntity,
+) -> Result<i64, sqlx::Error> {
+    let result = sqlx::query("INSERT INTO player (name, country_id, photo_path) VALUES (?, ?, ?)")
+        .bind(player.name)
+        .bind(player.country_id)
+        .bind(player.photo_path)
+        .execute(db)
+        .await?;
+
+    Ok(result.last_insert_rowid())
+}
+
+/// Get players with filters and pagination
+pub async fn get_players(
+    db: &SqlitePool,
+    filters: &PlayerFilters,
+    sort_field: &SortField,
+    sort_order: &SortOrder,
+    page: usize,
+    page_size: usize,
+) -> Result<PagedResult<PlayerEntity>, sqlx::Error> {
+    // Build count query
+    let mut count_query = sqlx::QueryBuilder::new(
+        "SELECT COUNT(*) as count FROM player p INNER JOIN country c ON p.country_id = c.id WHERE 1=1",
+    );
+    apply_filters(&mut count_query, filters);
+
+    let total: i64 = count_query.build().fetch_one(db).await?.get("count");
+
+    // Build data query
+    let mut data_query = sqlx::QueryBuilder::new(
+        "SELECT p.id, p.name, p.country_id, p.photo_path, c.name as country_name, c.iso2Code as country_iso2_code
+         FROM player p
+         INNER JOIN country c ON p.country_id = c.id
+         WHERE 1=1",
+    );
+    apply_filters(&mut data_query, filters);
+
+    // Apply sorting
+    data_query.push(" ORDER BY ");
+    data_query.push(sort_field.to_sql());
+    data_query.push(" ");
+    data_query.push(sort_order.to_sql());
+
+    // Apply pagination
+    let offset = (page - 1) * page_size;
+    data_query.push(" LIMIT ").push_bind(page_size as i64);
+    data_query.push(" OFFSET ").push_bind(offset as i64);
+
+    let rows = data_query.build().fetch_all(db).await?;
+
+    let items = rows
+        .into_iter()
+        .map(|row| PlayerEntity {
+            id: row.get("id"),
+            name: row.get("name"),
+            country_id: row.get("country_id"),
+            country_name: row.get("country_name"),
+            country_iso2_code: row.get("country_iso2_code"),
+            photo_path: row.get("photo_path"),
+        })
+        .collect();
+
+    Ok(PagedResult::new(items, total as usize, page, page_size))
+}
+
+/// Get a single player by ID
+pub async fn get_player_by_id(db: &SqlitePool, id: i64) -> Result<Option<PlayerEntity>, sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT p.id, p.name, p.country_id, p.photo_path, c.name as country_name, c.iso2Code as country_iso2_code
+         FROM player p
+         INNER JOIN country c ON p.country_id = c.id
+         WHERE p.id = ?",
+    )
+    .bind(id)
+    .fetch_optional(db)
+    .await?;
+
+    Ok(row.map(|row| PlayerEntity {
+        id: row.get("id"),
+        name: row.get("name"),
+        country_id: row.get("country_id"),
+        country_name: row.get("country_name"),
+        country_iso2_code: row.get("country_iso2_code"),
+        photo_path: row.get("photo_path"),
+    }))
+}
+
+/// Update a player
+pub async fn update_player(
+    db: &SqlitePool,
+    id: i64,
+    player: UpdatePlayerEntity,
+) -> Result<bool, sqlx::Error> {
+    let result = sqlx::query("UPDATE player SET name = ?, country_id = ?, photo_path = ? WHERE id = ?")
+        .bind(player.name)
+        .bind(player.country_id)
+        .bind(player.photo_path)
+        .bind(id)
+        .execute(db)
+        .await?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Delete a player
+pub async fn delete_player(db: &SqlitePool, id: i64) -> Result<bool, sqlx::Error> {
+    let result = sqlx::query("DELETE FROM player WHERE id = ?")
+        .bind(id)
+        .execute(db)
+        .await?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Helper function to apply filters to a query
+fn apply_filters<'a>(
+    query_builder: &mut sqlx::QueryBuilder<'a, sqlx::Sqlite>,
+    filters: &'a PlayerFilters,
+) {
+    if let Some(name) = &filters.name {
+        query_builder
+            .push(" AND p.name LIKE '%' || ")
+            .push_bind(name)
+            .push(" || '%'");
+    }
+
+    if let Some(country_id) = filters.country_id {
+        query_builder
+            .push(" AND p.country_id = ")
+            .push_bind(country_id);
+    }
+}
+
+/// Get all countries for dropdowns
+pub async fn get_countries(db: &SqlitePool) -> Result<Vec<(i64, String)>, sqlx::Error> {
+    let rows = sqlx::query("SELECT id, name FROM country ORDER BY name")
+        .fetch_all(db)
+        .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| (row.get("id"), row.get("name")))
+        .collect())
+}

--- a/frontend/src/views/components/mod.rs
+++ b/frontend/src/views/components/mod.rs
@@ -1,4 +1,5 @@
 pub mod error;
 pub mod sidebar;
+pub mod table;
 
 pub use sidebar::sidebar;

--- a/frontend/src/views/components/table.rs
+++ b/frontend/src/views/components/table.rs
@@ -1,0 +1,196 @@
+use maud::{html, Markup};
+
+use crate::common::pagination::{PagedResult, SortOrder};
+
+/// Generate page numbers for pagination with ellipsis for large page counts
+///
+/// Returns a vec of page numbers where 0 represents "..." (ellipsis).
+/// Always shows first page, last page, and pages around current page.
+///
+/// Examples:
+/// - Total 5 pages: [1, 2, 3, 4, 5]
+/// - Current page 1 of 20: [1, 2, 3, 0, 20]
+/// - Current page 10 of 20: [1, 0, 9, 10, 11, 0, 20]
+pub fn pagination_pages(current_page: usize, total_pages: usize) -> Vec<usize> {
+    let mut pages = Vec::new();
+
+    if total_pages <= 7 {
+        // Show all pages if there are 7 or fewer
+        for page in 1..=total_pages {
+            pages.push(page);
+        }
+    } else {
+        // Show first page
+        pages.push(1);
+
+        // Show pages around current page
+        let start = std::cmp::max(2, current_page.saturating_sub(1));
+        let end = std::cmp::min(total_pages - 1, current_page + 1);
+
+        if start > 2 {
+            pages.push(0); // Placeholder for "..."
+        }
+
+        for page in start..=end {
+            pages.push(page);
+        }
+
+        if end < total_pages - 1 {
+            pages.push(0); // Placeholder for "..."
+        }
+
+        // Show last page
+        pages.push(total_pages);
+    }
+
+    pages
+}
+
+/// Render pagination controls for a paged result
+///
+/// This is a generic pagination component that works with any entity type.
+/// Callers provide URL builders for navigation links.
+pub fn pagination_controls<T, F>(
+    result: &PagedResult<T>,
+    entity_name: &str,
+    build_page_url: F,
+) -> Markup
+where
+    F: Fn(usize) -> String,
+{
+    html! {
+        div style="display: flex; justify-content: space-between; align-items: center; margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--gray-200);" {
+            // Stats
+            div style="color: var(--gray-600); font-size: 0.875rem;" {
+                "Showing "
+                strong { (((result.page - 1) * result.page_size + 1)) }
+                " to "
+                strong { (std::cmp::min(result.page * result.page_size, result.total)) }
+                " of "
+                strong { (result.total) }
+                " " (entity_name)
+            }
+
+            // Page buttons
+            @if result.total_pages > 1 {
+                div style="display: flex; gap: 0.5rem;" {
+                    // Previous button
+                    @if result.has_previous {
+                        button
+                            class="btn btn-sm"
+                            hx-get=(build_page_url(result.page - 1))
+                            hx-target=(format!("#{}-table", entity_name))
+                            hx-swap="outerHTML"
+                        {
+                            "Previous"
+                        }
+                    } @else {
+                        button class="btn btn-sm" disabled { "Previous" }
+                    }
+
+                    // Page numbers
+                    @for page in pagination_pages(result.page, result.total_pages) {
+                        @if page == 0 {
+                            span style="padding: 0.25rem 0.5rem; color: var(--gray-400);" { "..." }
+                        } @else if page == result.page {
+                            button class="btn btn-sm btn-primary" disabled {
+                                (page)
+                            }
+                        } @else {
+                            button
+                                class="btn btn-sm"
+                                hx-get=(build_page_url(page))
+                                hx-target=(format!("#{}-table", entity_name))
+                                hx-swap="outerHTML"
+                            {
+                                (page)
+                            }
+                        }
+                    }
+
+                    // Next button
+                    @if result.has_next {
+                        button
+                            class="btn btn-sm"
+                            hx-get=(build_page_url(result.page + 1))
+                            hx-target=(format!("#{}-table", entity_name))
+                            hx-swap="outerHTML"
+                        {
+                            "Next"
+                        }
+                    } @else {
+                        button class="btn btn-sm" disabled { "Next" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Render a sortable table header with sort indicators
+///
+/// Generic sortable header component that shows sort direction indicators.
+/// Callers provide the URL for toggling sort on this column.
+pub fn sortable_header<F>(
+    label: &str,
+    is_active: bool,
+    current_order: &SortOrder,
+    entity_name: &str,
+    build_sort_url: F,
+) -> Markup
+where
+    F: Fn() -> String,
+{
+    // Choose the indicator
+    let indicator = if is_active {
+        match current_order {
+            SortOrder::Asc => "↑",
+            SortOrder::Desc => "↓",
+        }
+    } else {
+        "↕"
+    };
+
+    html! {
+        button
+            class="sort-button"
+            hx-get=(build_sort_url())
+            hx-target=(format!("#{}-table", entity_name))
+            hx-swap="outerHTML"
+            style="background: none; border: none; cursor: pointer; padding: 0; font-weight: 600; display: flex; align-items: center; gap: 0.25rem;"
+        {
+            (label)
+            span style=(if is_active { "font-size: 0.75rem; color: var(--primary-color);" } else { "font-size: 0.75rem;" }) {
+                (indicator)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pagination_pages_small() {
+        assert_eq!(pagination_pages(1, 5), vec![1, 2, 3, 4, 5]);
+        assert_eq!(pagination_pages(3, 5), vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_pagination_pages_large_at_start() {
+        assert_eq!(pagination_pages(1, 20), vec![1, 2, 0, 20]);
+        assert_eq!(pagination_pages(2, 20), vec![1, 2, 3, 0, 20]);
+    }
+
+    #[test]
+    fn test_pagination_pages_large_in_middle() {
+        assert_eq!(pagination_pages(10, 20), vec![1, 0, 9, 10, 11, 0, 20]);
+    }
+
+    #[test]
+    fn test_pagination_pages_large_at_end() {
+        assert_eq!(pagination_pages(19, 20), vec![1, 0, 18, 19, 20]);
+        assert_eq!(pagination_pages(20, 20), vec![1, 0, 19, 20]);
+    }
+}

--- a/frontend/src/views/pages/mod.rs
+++ b/frontend/src/views/pages/mod.rs
@@ -3,4 +3,5 @@ pub mod countries;
 pub mod dashboard;
 pub mod events;
 pub mod matches;
+pub mod players;
 pub mod teams;

--- a/frontend/src/views/pages/players.rs
+++ b/frontend/src/views/pages/players.rs
@@ -1,0 +1,589 @@
+use maud::{html, Markup, PreEscaped};
+
+use crate::service::players::{PagedResult, PlayerEntity, PlayerFilters, SortField, SortOrder};
+use crate::views::components::table::pagination_pages;
+
+/// Main players page with table and filters
+pub fn players_page(
+    result: &PagedResult<PlayerEntity>,
+    filters: &PlayerFilters,
+    sort_field: &SortField,
+    sort_order: &SortOrder,
+    countries: &[(i64, String)],
+) -> Markup {
+    html! {
+        div class="card" {
+            // Header with title and create button
+            div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;" {
+                div {
+                    h1 style="font-size: 2rem; font-weight: 700; margin-bottom: 0.5rem;" {
+                        "Players"
+                    }
+                    p style="color: var(--gray-600);" {
+                        "Manage and view all players in the system."
+                    }
+                }
+                button
+                    class="btn btn-primary"
+                    hx-get="/players/new"
+                    hx-target="#modal-container"
+                    hx-swap="innerHTML"
+                {
+                    "+ New Player"
+                }
+            }
+
+            // Filters
+            div style="margin-bottom: 1.5rem; padding: 1rem; background: var(--gray-50); border-radius: 8px;" {
+                form hx-get="/players/list" hx-target="#players-table" hx-swap="outerHTML" hx-trigger="submit, change delay:300ms" {
+                    div style="display: grid; grid-template-columns: 1fr 1fr auto; gap: 1rem; align-items: end;" {
+                        // Name filter
+                        div {
+                            label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                                "Search by name"
+                            }
+                            input
+                                type="text"
+                                name="name"
+                                value=[filters.name.as_ref()]
+                                placeholder="Enter player name..."
+                                style="width: 100%; padding: 0.5rem; border: 1px solid var(--gray-300); border-radius: 4px;";
+                        }
+
+                        // Country filter
+                        div {
+                            label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                                "Filter by country"
+                            }
+                            select
+                                name="country_id"
+                                style="width: 100%; padding: 0.5rem; border: 1px solid var(--gray-300); border-radius: 4px;"
+                            {
+                                option value="" { "All countries" }
+                                @for (id, name) in countries {
+                                    option
+                                        value=(id)
+                                        selected[filters.country_id == Some(*id)]
+                                    {
+                                        (name)
+                                    }
+                                }
+                            }
+                        }
+
+                        // Clear button
+                        div {
+                            button
+                                type="button"
+                                class="btn"
+                                style="background: white; border: 1px solid var(--gray-300);"
+                                hx-get="/players/list"
+                                hx-target="#players-table"
+                                hx-swap="outerHTML"
+                            {
+                                "Clear"
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Table
+            (player_list_content(result, filters, sort_field, sort_order))
+
+            // Modal container
+            div id="modal-container" {}
+        }
+    }
+}
+
+/// Players table content (for HTMX updates)
+pub fn player_list_content(
+    result: &PagedResult<PlayerEntity>,
+    filters: &PlayerFilters,
+    sort_field: &SortField,
+    sort_order: &SortOrder,
+) -> Markup {
+    html! {
+        div id="players-table" {
+            @if result.items.is_empty() {
+                div style="padding: 3rem; text-align: center; color: var(--gray-500);" {
+                    h3 style="font-size: 1.25rem; font-weight: 600; margin-bottom: 0.5rem;" {
+                        "No players found"
+                    }
+                    p {
+                        @if filters.name.is_some() || filters.country_id.is_some() {
+                            "No players match your search criteria. Try adjusting your filters."
+                        } @else {
+                            "No players have been added yet."
+                        }
+                    }
+                }
+            } @else {
+                table class="table" {
+                    thead {
+                        tr {
+                            th { "Photo" }
+                            th {
+                                (sortable_header(
+                                    "ID",
+                                    &SortField::Id,
+                                    sort_field,
+                                    sort_order,
+                                    filters,
+                                ))
+                            }
+                            th {
+                                (sortable_header(
+                                    "Name",
+                                    &SortField::Name,
+                                    sort_field,
+                                    sort_order,
+                                    filters,
+                                ))
+                            }
+                            th {
+                                (sortable_header(
+                                    "Country",
+                                    &SortField::Country,
+                                    sort_field,
+                                    sort_order,
+                                    filters,
+                                ))
+                            }
+                            th style="text-align: right;" { "Actions" }
+                        }
+                    }
+                    tbody {
+                        @for player in &result.items {
+                            tr {
+                                td {
+                                    @if let Some(photo_path) = &player.photo_path {
+                                        img
+                                            src=(photo_path)
+                                            alt=(format!("{} photo", player.name))
+                                            style="width: 40px; height: 40px; object-fit: cover; border-radius: 50%; border: 2px solid var(--gray-300);"
+                                            onerror="this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ccircle cx=%2250%22 cy=%2250%22 r=%2250%22 fill=%22%23e5e7eb%22/%3E%3Ctext x=%2250%25%22 y=%2250%25%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2240%22 fill=%22%23666%22%3E%3F%3C/text%3E%3C/svg%3E'";
+                                    } @else {
+                                        div
+                                            style="width: 40px; height: 40px; border-radius: 50%; background: var(--gray-200); display: flex; align-items: center; justify-content: center; font-weight: 600; color: var(--gray-600);"
+                                        {
+                                            (player.name.chars().next().unwrap_or('?').to_uppercase())
+                                        }
+                                    }
+                                }
+                                td { (player.id) }
+                                td { (player.name) }
+                                td {
+                                    span style="display: inline-flex; align-items: center; gap: 0.5rem;" {
+                                        img
+                                            src=(format!("https://flagcdn.com/w40/{}.png", player.country_iso2_code.to_lowercase()))
+                                            alt=(&player.country_name)
+                                            style="width: 20px; height: 15px; object-fit: cover; border: 1px solid var(--gray-300);"
+                                            onerror="this.style.display='none'";
+                                        (&player.country_name)
+                                    }
+                                }
+                                td style="text-align: right;" {
+                                    button
+                                        class="btn btn-sm"
+                                        hx-get=(format!("/players/{}/edit", player.id))
+                                        hx-target="#modal-container"
+                                        hx-swap="innerHTML"
+                                        style="margin-right: 0.5rem;"
+                                    {
+                                        "Edit"
+                                    }
+                                    button
+                                        class="btn btn-sm btn-danger"
+                                        hx-post=(format!("/players/{}/delete", player.id))
+                                        hx-target="#players-table"
+                                        hx-swap="outerHTML"
+                                        hx-confirm="Are you sure you want to delete this player?"
+                                    {
+                                        "Delete"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Pagination
+                (pagination(result, filters, sort_field, sort_order))
+            }
+        }
+    }
+}
+
+/// Sortable table header
+fn sortable_header(
+    label: &str,
+    field: &SortField,
+    current_sort: &SortField,
+    current_order: &SortOrder,
+    filters: &PlayerFilters,
+) -> Markup {
+    // Determine if this column is currently sorted
+    let is_active = matches!(
+        (field, current_sort),
+        (SortField::Id, SortField::Id)
+            | (SortField::Name, SortField::Name)
+            | (SortField::Country, SortField::Country)
+    );
+
+    // If this column is active, toggle the order; otherwise default to ASC
+    let next_order = if is_active {
+        current_order.toggle()
+    } else {
+        SortOrder::Asc
+    };
+
+    // Build the URL
+    let url = build_sort_url(field, &next_order, filters);
+
+    // Choose the indicator
+    let indicator = if is_active {
+        match current_order {
+            SortOrder::Asc => "↑",
+            SortOrder::Desc => "↓",
+        }
+    } else {
+        "↕"
+    };
+
+    html! {
+        button
+            class="sort-button"
+            hx-get=(url)
+            hx-target="#players-table"
+            hx-swap="outerHTML"
+            style="background: none; border: none; cursor: pointer; padding: 0; font-weight: 600; display: flex; align-items: center; gap: 0.25rem;"
+        {
+            (label)
+            span style=(if is_active { "font-size: 0.75rem; color: var(--primary-color);" } else { "font-size: 0.75rem;" }) {
+                (indicator)
+            }
+        }
+    }
+}
+
+/// Helper to build sort URLs
+fn build_sort_url(field: &SortField, order: &SortOrder, filters: &PlayerFilters) -> String {
+    let mut url = format!("/players/list?sort={}&order={}", field.as_str(), order.as_str());
+
+    if let Some(name) = &filters.name {
+        url.push_str(&format!("&name={}", urlencoding::encode(name)));
+    }
+
+    if let Some(country_id) = filters.country_id {
+        url.push_str(&format!("&country_id={}", country_id));
+    }
+
+    url
+}
+
+/// Pagination component
+fn pagination(
+    result: &PagedResult<PlayerEntity>,
+    filters: &PlayerFilters,
+    sort_field: &SortField,
+    sort_order: &SortOrder,
+) -> Markup {
+    html! {
+        div style="display: flex; justify-content: space-between; align-items: center; margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--gray-200);" {
+            // Stats
+            div style="color: var(--gray-600); font-size: 0.875rem;" {
+                "Showing "
+                strong { (((result.page - 1) * result.page_size + 1)) }
+                " to "
+                strong { (std::cmp::min(result.page * result.page_size, result.total)) }
+                " of "
+                strong { (result.total) }
+                " players"
+            }
+
+            // Page buttons
+            @if result.total_pages > 1 {
+                div style="display: flex; gap: 0.5rem;" {
+                    // Previous button
+                    @if result.has_previous {
+                        button
+                            class="btn btn-sm"
+                            hx-get=(build_pagination_url(result.page - 1, result.page_size, filters, sort_field, sort_order))
+                            hx-target="#players-table"
+                            hx-swap="outerHTML"
+                        {
+                            "Previous"
+                        }
+                    } @else {
+                        button class="btn btn-sm" disabled { "Previous" }
+                    }
+
+                    // Page numbers
+                    @for page in pagination_pages(result.page, result.total_pages) {
+                        @if page == 0 {
+                            span style="padding: 0.25rem 0.5rem; color: var(--gray-400);" { "..." }
+                        } @else if page == result.page {
+                            button class="btn btn-sm btn-primary" disabled {
+                                (page)
+                            }
+                        } @else {
+                            button
+                                class="btn btn-sm"
+                                hx-get=(build_pagination_url(page, result.page_size, filters, sort_field, sort_order))
+                                hx-target="#players-table"
+                                hx-swap="outerHTML"
+                            {
+                                (page)
+                            }
+                        }
+                    }
+
+                    // Next button
+                    @if result.has_next {
+                        button
+                            class="btn btn-sm"
+                            hx-get=(build_pagination_url(result.page + 1, result.page_size, filters, sort_field, sort_order))
+                            hx-target="#players-table"
+                            hx-swap="outerHTML"
+                        {
+                            "Next"
+                        }
+                    } @else {
+                        button class="btn btn-sm" disabled { "Next" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Helper to build pagination URLs with filters and sorting
+fn build_pagination_url(
+    page: usize,
+    page_size: usize,
+    filters: &PlayerFilters,
+    sort_field: &SortField,
+    sort_order: &SortOrder,
+) -> String {
+    let mut url = format!(
+        "/players/list?page={}&page_size={}&sort={}&order={}",
+        page,
+        page_size,
+        sort_field.as_str(),
+        sort_order.as_str()
+    );
+
+    if let Some(name) = &filters.name {
+        url.push_str(&format!("&name={}", urlencoding::encode(name)));
+    }
+
+    if let Some(country_id) = filters.country_id {
+        url.push_str(&format!("&country_id={}", country_id));
+    }
+
+    url
+}
+
+/// Create player modal
+pub fn player_create_modal(error: Option<&str>, countries: &[(i64, String)]) -> Markup {
+    html! {
+        div
+            class="modal-backdrop"
+            style="position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.5); display: flex; align-items: center; justify-content: center; z-index: 1000;"
+            id="player-modal"
+        {
+            div
+                class="modal"
+                style="background: white; border-radius: 12px; padding: 2rem; max-width: 500px; width: 90%; max-height: 90vh; overflow-y: auto;"
+                onclick="event.stopPropagation()"
+            {
+                h2 style="margin-bottom: 1.5rem; font-size: 1.5rem; font-weight: 700;" {
+                    "Create Player"
+                }
+
+                @if let Some(error_msg) = error {
+                    div class="error" style="margin-bottom: 1rem; padding: 0.75rem; background: #fee; border: 1px solid #fcc; border-radius: 4px; color: #c00;" {
+                        (error_msg)
+                    }
+                }
+
+                form hx-post="/players" hx-target="#player-modal" hx-swap="outerHTML" {
+                    div style="margin-bottom: 1rem;" {
+                        label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                            "Player Name"
+                            span style="color: red;" { "*" }
+                        }
+                        input
+                            type="text"
+                            name="name"
+                            required
+                            autofocus
+                            style="width: 100%; padding: 0.5rem; border: 1px solid var(--gray-300); border-radius: 4px;";
+                    }
+
+                    div style="margin-bottom: 1rem;" {
+                        label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                            "Country"
+                            span style="color: red;" { "*" }
+                        }
+                        select
+                            name="country_id"
+                            required
+                            style="width: 100%; padding: 0.5rem; border: 1px solid var(--gray-300); border-radius: 4px;"
+                        {
+                            option value="" { "Select a country" }
+                            @for (id, name) in countries {
+                                option value=(id) {
+                                    (name)
+                                }
+                            }
+                        }
+                    }
+
+                    div style="margin-bottom: 1.5rem;" {
+                        label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                            "Photo URL"
+                        }
+                        input
+                            type="url"
+                            name="photo_path"
+                            placeholder="https://example.com/photo.jpg"
+                            style="width: 100%; padding: 0.5rem; border: 1px solid var(--gray-300); border-radius: 4px;";
+                        p style="font-size: 0.75rem; color: var(--gray-500); margin-top: 0.25rem;" {
+                            "Optional: URL to player photo"
+                        }
+                    }
+
+                    div style="display: flex; gap: 0.5rem; justify-content: flex-end;" {
+                        button
+                            type="button"
+                            class="btn"
+                            style="background: white; border: 1px solid var(--gray-300);"
+                            onclick="document.getElementById('player-modal').remove()"
+                        {
+                            "Cancel"
+                        }
+                        button type="submit" class="btn btn-primary" {
+                            "Create Player"
+                        }
+                    }
+                }
+            }
+        }
+        (PreEscaped(r#"
+        <script>
+            document.getElementById('player-modal').addEventListener('click', function(e) {
+                if (e.target === this) {
+                    this.remove();
+                }
+            });
+        </script>
+        "#))
+    }
+}
+
+/// Edit player modal
+pub fn player_edit_modal(
+    player: &PlayerEntity,
+    error: Option<&str>,
+    countries: &[(i64, String)],
+) -> Markup {
+    html! {
+        div
+            class="modal-backdrop"
+            style="position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.5); display: flex; align-items: center; justify-content: center; z-index: 1000;"
+            id="player-modal"
+        {
+            div
+                class="modal"
+                style="background: white; border-radius: 12px; padding: 2rem; max-width: 500px; width: 90%; max-height: 90vh; overflow-y: auto;"
+                onclick="event.stopPropagation()"
+            {
+                h2 style="margin-bottom: 1.5rem; font-size: 1.5rem; font-weight: 700;" {
+                    "Edit Player"
+                }
+
+                @if let Some(error_msg) = error {
+                    div class="error" style="margin-bottom: 1rem; padding: 0.75rem; background: #fee; border: 1px solid #fcc; border-radius: 4px; color: #c00;" {
+                        (error_msg)
+                    }
+                }
+
+                form hx-post=(format!("/players/{}", player.id)) hx-target="#player-modal" hx-swap="outerHTML" {
+                    div style="margin-bottom: 1rem;" {
+                        label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                            "Player Name"
+                            span style="color: red;" { "*" }
+                        }
+                        input
+                            type="text"
+                            name="name"
+                            value=(player.name)
+                            required
+                            autofocus
+                            style="width: 100%; padding: 0.5rem; border: 1px solid var(--gray-300); border-radius: 4px;";
+                    }
+
+                    div style="margin-bottom: 1rem;" {
+                        label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                            "Country"
+                            span style="color: red;" { "*" }
+                        }
+                        select
+                            name="country_id"
+                            required
+                            style="width: 100%; padding: 0.5rem; border: 1px solid var(--gray-300); border-radius: 4px;"
+                        {
+                            option value="" { "Select a country" }
+                            @for (id, name) in countries {
+                                option value=(id) selected[*id == player.country_id] {
+                                    (name)
+                                }
+                            }
+                        }
+                    }
+
+                    div style="margin-bottom: 1.5rem;" {
+                        label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                            "Photo URL"
+                        }
+                        input
+                            type="url"
+                            name="photo_path"
+                            value=[player.photo_path.as_ref()]
+                            placeholder="https://example.com/photo.jpg"
+                            style="width: 100%; padding: 0.5rem; border: 1px solid var(--gray-300); border-radius: 4px;";
+                        p style="font-size: 0.75rem; color: var(--gray-500); margin-top: 0.25rem;" {
+                            "Optional: URL to player photo"
+                        }
+                    }
+
+                    div style="display: flex; gap: 0.5rem; justify-content: flex-end;" {
+                        button
+                            type="button"
+                            class="btn"
+                            style="background: white; border: 1px solid var(--gray-300);"
+                            onclick="document.getElementById('player-modal').remove()"
+                        {
+                            "Cancel"
+                        }
+                        button type="submit" class="btn btn-primary" {
+                            "Save Changes"
+                        }
+                    }
+                }
+            }
+        }
+        (PreEscaped(r#"
+        <script>
+            document.getElementById('player-modal').addEventListener('click', function(e) {
+                if (e.target === this) {
+                    this.remove();
+                }
+            });
+        </script>
+        "#))
+    }
+}


### PR DESCRIPTION
## Summary

Implements comprehensive players management page with full CRUD operations and introduces reusable table components that will benefit future pages.

**Key Features:**
- Players list with filtering (name, country), sorting, and pagination
- CRUD operations via HTMX-powered modals
- Reusable table components (pagination controls, sortable headers)
- Country dropdown integration for player nationality
- Follows established patterns from teams/countries management

**New Components:**
- `frontend/src/common/pagination.rs` - Generic pagination types
- `frontend/src/views/components/table.rs` - Reusable table components with pagination and sorting

**Implementation:**
- Route handlers following naming conventions (`players_get`, `player_create_form`, etc.)
- Service layer with dynamic filtering and sorting using SQLx QueryBuilder
- Maud templates with HTMX for dynamic updates
- Proper validation and error handling

**Routes Added:**
- `GET /players` - Full players page
- `GET /players/list` - HTMX partial for table updates
- `GET /players/new` - Create modal
- `POST /players` - Create action
- `GET /players/:id/edit` - Edit modal
- `POST /players/:id` - Update action
- `POST /players/:id/delete` - Delete action

## Test plan
- [x] Players page loads with correct data
- [x] Filtering by name works
- [x] Filtering by country works
- [x] Sorting by ID, name, and country works (both directions)
- [x] Pagination controls work correctly
- [x] Create player modal opens and submits
- [x] Edit player modal opens with existing data
- [x] Delete player works
- [x] Validation errors display properly
- [x] Country flags display in table

🤖 Generated with [Claude Code](https://claude.com/claude-code)