### PR TITLE
feat: implement season management using the common table component

### DIFF
--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -105,6 +105,13 @@ async fn main() -> Result<(), anyhow::Error> {
         .route("/players/:id/edit", get(routes::players::player_edit_form))
         .route("/players/:id", post(routes::players::player_update))
         .route("/players/:id/delete", post(routes::players::player_delete))
+        .route("/seasons", get(routes::seasons::seasons_get))
+        .route("/seasons/list", get(routes::seasons::seasons_list_partial))
+        .route("/seasons/new", get(routes::seasons::season_create_form))
+        .route("/seasons", post(routes::seasons::season_create))
+        .route("/seasons/:id/edit", get(routes::seasons::season_edit_form))
+        .route("/seasons/:id", post(routes::seasons::season_update))
+        .route("/seasons/:id/delete", post(routes::seasons::season_delete))
         .route("/matches/:id", get(routes::matches::match_detail))
         .route("/matches/:id/delete", post(routes::matches::match_delete))
         .layer(middleware::from_fn_with_state(state.clone(), require_auth));

--- a/frontend/src/routes/mod.rs
+++ b/frontend/src/routes/mod.rs
@@ -3,4 +3,5 @@ pub mod countries;
 pub mod events;
 pub mod matches;
 pub mod players;
+pub mod seasons;
 pub mod teams;

--- a/frontend/src/routes/seasons.rs
+++ b/frontend/src/routes/seasons.rs
@@ -1,0 +1,366 @@
+use axum::{
+    extract::{Path, Query, State},
+    response::{Html, IntoResponse},
+    Extension, Form,
+};
+use serde::Deserialize;
+
+use crate::app_state::AppState;
+use crate::auth::Session;
+use crate::i18n::Locale;
+use crate::service::seasons::{
+    self, CreateSeasonEntity, SeasonFilters, SortField, SortOrder, UpdateSeasonEntity,
+};
+use crate::views::{
+    layout::admin_layout,
+    pages::seasons::{season_create_modal, season_edit_modal, season_list_content, seasons_page},
+};
+
+#[derive(Debug, Deserialize)]
+pub struct SeasonsQuery {
+    #[serde(default = "default_page")]
+    page: usize,
+    #[serde(default = "default_page_size")]
+    page_size: usize,
+    #[serde(default, deserialize_with = "crate::utils::empty_string_as_none_i64")]
+    event_id: Option<i64>,
+    #[serde(default, deserialize_with = "crate::utils::empty_string_as_none_i64")]
+    year: Option<i64>,
+    #[serde(default = "default_sort")]
+    sort: String,
+    #[serde(default = "default_sort_order")]
+    order: String,
+}
+
+fn default_page() -> usize {
+    1
+}
+
+fn default_page_size() -> usize {
+    20
+}
+
+fn default_sort() -> String {
+    "year".to_string()
+}
+
+fn default_sort_order() -> String {
+    "desc".to_string()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateSeasonForm {
+    year: i64,
+    display_name: Option<String>,
+    event_id: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateSeasonForm {
+    year: i64,
+    display_name: Option<String>,
+    event_id: i64,
+}
+
+/// GET /seasons - Seasons list page
+pub async fn seasons_get(
+    Extension(session): Extension<Session>,
+    State(state): State<AppState>,
+    Query(query): Query<SeasonsQuery>,
+) -> impl IntoResponse {
+    let locale = Locale::English;
+
+    // Build filters
+    let filters = SeasonFilters {
+        event_id: query.event_id,
+        year: query.year,
+    };
+
+    // Parse sorting
+    let sort_field = SortField::from_str(&query.sort);
+    let sort_order = SortOrder::from_str(&query.order);
+
+    // Get seasons
+    let result = match seasons::get_seasons(
+        &state.db,
+        &filters,
+        &sort_field,
+        &sort_order,
+        query.page,
+        query.page_size,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::error!("Failed to fetch seasons: {}", e);
+            return Html(
+                admin_layout(
+                    "Seasons",
+                    &session,
+                    "/seasons",
+                    &state.i18n,
+                    locale,
+                    crate::views::components::error::error_message("Failed to load seasons"),
+                )
+                .into_string(),
+            );
+        }
+    };
+
+    // Get events for filter
+    let events = seasons::get_events(&state.db).await.unwrap_or_default();
+
+    let content = seasons_page(&result, &filters, &sort_field, &sort_order, &events);
+    Html(admin_layout("Seasons", &session, "/seasons", &state.i18n, locale, content).into_string())
+}
+
+/// GET /seasons/list - HTMX endpoint for table updates
+pub async fn seasons_list_partial(
+    State(state): State<AppState>,
+    Query(query): Query<SeasonsQuery>,
+) -> impl IntoResponse {
+    let filters = SeasonFilters {
+        event_id: query.event_id,
+        year: query.year,
+    };
+
+    // Parse sorting
+    let sort_field = SortField::from_str(&query.sort);
+    let sort_order = SortOrder::from_str(&query.order);
+
+    let result = match seasons::get_seasons(
+        &state.db,
+        &filters,
+        &sort_field,
+        &sort_order,
+        query.page,
+        query.page_size,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::error!("Failed to fetch seasons: {}", e);
+            return Html(
+                crate::views::components::error::error_message("Failed to load seasons")
+                    .into_string(),
+            );
+        }
+    };
+
+    Html(season_list_content(&result, &filters, &sort_field, &sort_order).into_string())
+}
+
+/// GET /seasons/new - Show create modal
+pub async fn season_create_form(State(state): State<AppState>) -> impl IntoResponse {
+    let events = seasons::get_events(&state.db).await.unwrap_or_default();
+    Html(season_create_modal(None, &events).into_string())
+}
+
+/// POST /seasons - Create new season
+pub async fn season_create(
+    State(state): State<AppState>,
+    Form(form): Form<CreateSeasonForm>,
+) -> impl IntoResponse {
+    // Get events for form re-render on error
+    let events = seasons::get_events(&state.db).await.unwrap_or_default();
+
+    // Validation
+    if form.year < 1900 || form.year > 2100 {
+        return Html(season_create_modal(Some("Year must be between 1900 and 2100"), &events).into_string());
+    }
+
+    if let Some(display_name) = &form.display_name {
+        let trimmed = display_name.trim();
+        if !trimmed.is_empty() && trimmed.len() > 255 {
+            return Html(
+                season_create_modal(
+                    Some("Display name cannot exceed 255 characters"),
+                    &events,
+                )
+                .into_string(),
+            );
+        }
+    }
+
+    // Create season
+    match seasons::create_season(
+        &state.db,
+        CreateSeasonEntity {
+            year: form.year,
+            display_name: form.display_name.and_then(|s| {
+                let trimmed = s.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            }),
+            event_id: form.event_id,
+        },
+    )
+    .await
+    {
+        Ok(_) => {
+            // Return HTMX response to close modal and reload table
+            Html("<div hx-get=\"/seasons/list\" hx-target=\"#seasons-table\" hx-trigger=\"load\" hx-swap=\"outerHTML\"></div>".to_string())
+        }
+        Err(e) => {
+            tracing::error!("Failed to create season: {}", e);
+            Html(season_create_modal(Some("Failed to create season"), &events).into_string())
+        }
+    }
+}
+
+/// GET /seasons/{id}/edit - Show edit modal
+pub async fn season_edit_form(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> impl IntoResponse {
+    let events = seasons::get_events(&state.db).await.unwrap_or_default();
+
+    let season = match seasons::get_season_by_id(&state.db, id).await {
+        Ok(Some(season)) => season,
+        Ok(None) => {
+            return Html(
+                crate::views::components::error::error_message("Season not found").into_string(),
+            );
+        }
+        Err(e) => {
+            tracing::error!("Failed to fetch season: {}", e);
+            return Html(
+                crate::views::components::error::error_message("Failed to load season")
+                    .into_string(),
+            );
+        }
+    };
+
+    Html(season_edit_modal(&season, None, &events).into_string())
+}
+
+/// POST /seasons/{id} - Update season
+pub async fn season_update(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    Form(form): Form<UpdateSeasonForm>,
+) -> impl IntoResponse {
+    let events = seasons::get_events(&state.db).await.unwrap_or_default();
+
+    // Validation
+    if form.year < 1900 || form.year > 2100 {
+        let season = seasons::get_season_by_id(&state.db, id).await.ok().flatten();
+        return Html(
+            season_edit_modal(
+                &season.unwrap(),
+                Some("Year must be between 1900 and 2100"),
+                &events,
+            )
+            .into_string(),
+        );
+    }
+
+    if let Some(display_name) = &form.display_name {
+        let trimmed = display_name.trim();
+        if !trimmed.is_empty() && trimmed.len() > 255 {
+            let season = seasons::get_season_by_id(&state.db, id).await.ok().flatten();
+            return Html(
+                season_edit_modal(
+                    &season.unwrap(),
+                    Some("Display name cannot exceed 255 characters"),
+                    &events,
+                )
+                .into_string(),
+            );
+        }
+    }
+
+    // Update season
+    match seasons::update_season(
+        &state.db,
+        id,
+        UpdateSeasonEntity {
+            year: form.year,
+            display_name: form.display_name.and_then(|s| {
+                let trimmed = s.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            }),
+            event_id: form.event_id,
+        },
+    )
+    .await
+    {
+        Ok(true) => {
+            // Return HTMX response to close modal and reload table
+            Html("<div hx-get=\"/seasons/list\" hx-target=\"#seasons-table\" hx-trigger=\"load\" hx-swap=\"outerHTML\"></div>".to_string())
+        }
+        Ok(false) => {
+            let season = seasons::get_season_by_id(&state.db, id).await.ok().flatten();
+            Html(season_edit_modal(&season.unwrap(), Some("Season not found"), &events).into_string())
+        }
+        Err(e) => {
+            tracing::error!("Failed to update season: {}", e);
+            let season = seasons::get_season_by_id(&state.db, id).await.ok().flatten();
+            Html(
+                season_edit_modal(&season.unwrap(), Some("Failed to update season"), &events)
+                    .into_string(),
+            )
+        }
+    }
+}
+
+/// POST /seasons/{id}/delete - Delete season
+pub async fn season_delete(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    Query(query): Query<SeasonsQuery>,
+) -> impl IntoResponse {
+    match seasons::delete_season(&state.db, id).await {
+        Ok(true) => {
+            // Reload the table content after successful delete
+            let filters = SeasonFilters {
+                event_id: query.event_id,
+                year: query.year,
+            };
+
+            let sort_field = SortField::from_str(&query.sort);
+            let sort_order = SortOrder::from_str(&query.order);
+
+            let result = match seasons::get_seasons(
+                &state.db,
+                &filters,
+                &sort_field,
+                &sort_order,
+                query.page,
+                query.page_size,
+            )
+            .await
+            {
+                Ok(result) => result,
+                Err(e) => {
+                    tracing::error!("Failed to fetch seasons after delete: {}", e);
+                    return Html(
+                        crate::views::components::error::error_message("Failed to reload seasons")
+                            .into_string(),
+                    );
+                }
+            };
+
+            Html(season_list_content(&result, &filters, &sort_field, &sort_order).into_string())
+        }
+        Ok(false) => Html(
+            crate::views::components::error::error_message("Season not found").into_string(),
+        ),
+        Err(e) => {
+            tracing::error!("Failed to delete season: {}", e);
+            Html(
+                crate::views::components::error::error_message("Failed to delete season")
+                    .into_string(),
+            )
+        }
+    }
+}

--- a/frontend/src/service/mod.rs
+++ b/frontend/src/service/mod.rs
@@ -2,4 +2,5 @@ pub mod countries;
 pub mod events;
 pub mod matches;
 pub mod players;
+pub mod seasons;
 pub mod teams;

--- a/frontend/src/service/seasons.rs
+++ b/frontend/src/service/seasons.rs
@@ -1,0 +1,213 @@
+use sqlx::{Row, SqlitePool};
+
+// Re-export common pagination types for convenience
+pub use crate::common::pagination::{PagedResult, SortOrder};
+
+#[derive(Debug, Clone)]
+pub struct SeasonEntity {
+    pub id: i64,
+    pub year: i64,
+    pub display_name: Option<String>,
+    pub event_id: i64,
+    pub event_name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateSeasonEntity {
+    pub year: i64,
+    pub display_name: Option<String>,
+    pub event_id: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateSeasonEntity {
+    pub year: i64,
+    pub display_name: Option<String>,
+    pub event_id: i64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SeasonFilters {
+    pub event_id: Option<i64>,
+    pub year: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SortField {
+    Id,
+    Year,
+    Event,
+}
+
+impl SortField {
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "id" => Self::Id,
+            "year" => Self::Year,
+            "event" => Self::Event,
+            _ => Self::Year, // Default
+        }
+    }
+
+    pub fn to_sql(&self) -> &'static str {
+        match self {
+            Self::Id => "s.id",
+            Self::Year => "s.year",
+            Self::Event => "e.name",
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Id => "id",
+            Self::Year => "year",
+            Self::Event => "event",
+        }
+    }
+}
+
+/// Create a new season
+pub async fn create_season(
+    db: &SqlitePool,
+    season: CreateSeasonEntity,
+) -> Result<i64, sqlx::Error> {
+    let result = sqlx::query("INSERT INTO season (year, display_name, event_id) VALUES (?, ?, ?)")
+        .bind(season.year)
+        .bind(season.display_name)
+        .bind(season.event_id)
+        .execute(db)
+        .await?;
+
+    Ok(result.last_insert_rowid())
+}
+
+/// Get seasons with filters and pagination
+pub async fn get_seasons(
+    db: &SqlitePool,
+    filters: &SeasonFilters,
+    sort_field: &SortField,
+    sort_order: &SortOrder,
+    page: usize,
+    page_size: usize,
+) -> Result<PagedResult<SeasonEntity>, sqlx::Error> {
+    // Build count query
+    let mut count_query = sqlx::QueryBuilder::new(
+        "SELECT COUNT(*) as count FROM season s INNER JOIN event e ON s.event_id = e.id WHERE 1=1",
+    );
+    apply_filters(&mut count_query, filters);
+
+    let total: i64 = count_query.build().fetch_one(db).await?.get("count");
+
+    // Build data query
+    let mut data_query = sqlx::QueryBuilder::new(
+        "SELECT s.id, s.year, s.display_name, s.event_id, e.name as event_name
+         FROM season s
+         INNER JOIN event e ON s.event_id = e.id
+         WHERE 1=1",
+    );
+    apply_filters(&mut data_query, filters);
+
+    // Apply sorting
+    data_query.push(" ORDER BY ");
+    data_query.push(sort_field.to_sql());
+    data_query.push(" ");
+    data_query.push(sort_order.to_sql());
+
+    // Apply pagination
+    let offset = (page - 1) * page_size;
+    data_query.push(" LIMIT ").push_bind(page_size as i64);
+    data_query.push(" OFFSET ").push_bind(offset as i64);
+
+    let rows = data_query.build().fetch_all(db).await?;
+
+    let items = rows
+        .into_iter()
+        .map(|row| SeasonEntity {
+            id: row.get("id"),
+            year: row.get("year"),
+            display_name: row.get("display_name"),
+            event_id: row.get("event_id"),
+            event_name: row.get("event_name"),
+        })
+        .collect();
+
+    Ok(PagedResult::new(items, total as usize, page, page_size))
+}
+
+/// Get a single season by ID
+pub async fn get_season_by_id(db: &SqlitePool, id: i64) -> Result<Option<SeasonEntity>, sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT s.id, s.year, s.display_name, s.event_id, e.name as event_name
+         FROM season s
+         INNER JOIN event e ON s.event_id = e.id
+         WHERE s.id = ?",
+    )
+    .bind(id)
+    .fetch_optional(db)
+    .await?;
+
+    Ok(row.map(|row| SeasonEntity {
+        id: row.get("id"),
+        year: row.get("year"),
+        display_name: row.get("display_name"),
+        event_id: row.get("event_id"),
+        event_name: row.get("event_name"),
+    }))
+}
+
+/// Update a season
+pub async fn update_season(
+    db: &SqlitePool,
+    id: i64,
+    season: UpdateSeasonEntity,
+) -> Result<bool, sqlx::Error> {
+    let result = sqlx::query("UPDATE season SET year = ?, display_name = ?, event_id = ? WHERE id = ?")
+        .bind(season.year)
+        .bind(season.display_name)
+        .bind(season.event_id)
+        .bind(id)
+        .execute(db)
+        .await?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Delete a season
+pub async fn delete_season(db: &SqlitePool, id: i64) -> Result<bool, sqlx::Error> {
+    let result = sqlx::query("DELETE FROM season WHERE id = ?")
+        .bind(id)
+        .execute(db)
+        .await?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Helper function to apply filters to a query
+fn apply_filters<'a>(
+    query_builder: &mut sqlx::QueryBuilder<'a, sqlx::Sqlite>,
+    filters: &'a SeasonFilters,
+) {
+    if let Some(event_id) = filters.event_id {
+        query_builder
+            .push(" AND s.event_id = ")
+            .push_bind(event_id);
+    }
+
+    if let Some(year) = filters.year {
+        query_builder
+            .push(" AND s.year = ")
+            .push_bind(year);
+    }
+}
+
+/// Get all events for dropdowns
+pub async fn get_events(db: &SqlitePool) -> Result<Vec<(i64, String)>, sqlx::Error> {
+    let rows = sqlx::query("SELECT id, name FROM event ORDER BY name")
+        .fetch_all(db)
+        .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| (row.get("id"), row.get("name")))
+        .collect())
+}

--- a/frontend/src/views/components/crud.rs
+++ b/frontend/src/views/components/crud.rs
@@ -1,0 +1,236 @@
+use maud::{html, Markup, PreEscaped};
+
+use crate::common::pagination::PagedResult;
+use crate::views::components::table::pagination_pages;
+
+/// Page header with title, description, and create button
+pub fn page_header(
+    title: &str,
+    description: &str,
+    create_url: &str,
+    create_label: &str,
+) -> Markup {
+    html! {
+        div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;" {
+            div {
+                h1 style="font-size: 2rem; font-weight: 700; margin-bottom: 0.5rem;" {
+                    (title)
+                }
+                p style="color: var(--gray-600);" {
+                    (description)
+                }
+            }
+            button
+                class="btn btn-primary"
+                hx-get=(create_url)
+                hx-target="#modal-container"
+                hx-swap="innerHTML"
+            {
+                (create_label)
+            }
+        }
+    }
+}
+
+/// Empty state when no items are found
+pub fn empty_state(entity_name: &str, has_filters: bool) -> Markup {
+    html! {
+        div style="padding: 3rem; text-align: center; color: var(--gray-500);" {
+            h3 style="font-size: 1.25rem; font-weight: 600; margin-bottom: 0.5rem;" {
+                "No " (entity_name) " found"
+            }
+            p {
+                @if has_filters {
+                    "No " (entity_name) " match your search criteria. Try adjusting your filters."
+                } @else {
+                    "No " (entity_name) " have been added yet."
+                }
+            }
+        }
+    }
+}
+
+/// Generic pagination component
+///
+/// # Parameters
+/// - `result`: The paged result with items and pagination metadata
+/// - `entity_name`: Name of the entity for display (e.g., "players", "seasons")
+/// - `build_url`: Function that takes a page number and returns the URL for that page
+/// - `target_id`: The ID of the element to update (e.g., "players-table")
+pub fn pagination<T, F>(
+    result: &PagedResult<T>,
+    entity_name: &str,
+    build_url: F,
+    target_id: &str,
+) -> Markup
+where
+    F: Fn(usize) -> String,
+{
+    html! {
+        div style="display: flex; justify-content: space-between; align-items: center; margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--gray-200);" {
+            // Stats
+            div style="color: var(--gray-600); font-size: 0.875rem;" {
+                "Showing "
+                strong { (((result.page - 1) * result.page_size + 1)) }
+                " to "
+                strong { (std::cmp::min(result.page * result.page_size, result.total)) }
+                " of "
+                strong { (result.total) }
+                " " (entity_name)
+            }
+
+            // Page buttons
+            @if result.total_pages > 1 {
+                div style="display: flex; gap: 0.5rem;" {
+                    // Previous button
+                    @if result.has_previous {
+                        button
+                            class="btn btn-sm"
+                            hx-get=(build_url(result.page - 1))
+                            hx-target=(format!("#{}", target_id))
+                            hx-swap="outerHTML"
+                        {
+                            "Previous"
+                        }
+                    } @else {
+                        button class="btn btn-sm" disabled { "Previous" }
+                    }
+
+                    // Page numbers
+                    @for page in pagination_pages(result.page, result.total_pages) {
+                        @if page == 0 {
+                            span style="padding: 0.25rem 0.5rem; color: var(--gray-400);" { "..." }
+                        } @else if page == result.page {
+                            button class="btn btn-sm btn-primary" disabled {
+                                (page)
+                            }
+                        } @else {
+                            button
+                                class="btn btn-sm"
+                                hx-get=(build_url(page))
+                                hx-target=(format!("#{}", target_id))
+                                hx-swap="outerHTML"
+                            {
+                                (page)
+                            }
+                        }
+                    }
+
+                    // Next button
+                    @if result.has_next {
+                        button
+                            class="btn btn-sm"
+                            hx-get=(build_url(result.page + 1))
+                            hx-target=(format!("#{}", target_id))
+                            hx-swap="outerHTML"
+                        {
+                            "Next"
+                        }
+                    } @else {
+                        button class="btn btn-sm" disabled { "Next" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Modal wrapper with backdrop and form structure
+///
+/// # Parameters
+/// - `modal_id`: Unique ID for this modal (e.g., "player-modal", "season-modal")
+/// - `title`: Modal title
+/// - `error`: Optional error message to display
+/// - `form_action`: POST URL for form submission
+/// - `form_fields`: The form fields markup
+/// - `submit_label`: Label for the submit button
+pub fn modal_form(
+    modal_id: &str,
+    title: &str,
+    error: Option<&str>,
+    form_action: &str,
+    form_fields: Markup,
+    submit_label: &str,
+) -> Markup {
+    html! {
+        div
+            class="modal-backdrop"
+            style="position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.5); display: flex; align-items: center; justify-content: center; z-index: 1000;"
+            id=(modal_id)
+        {
+            div
+                class="modal"
+                style="background: white; border-radius: 12px; padding: 2rem; max-width: 500px; width: 90%; max-height: 90vh; overflow-y: auto;"
+                onclick="event.stopPropagation()"
+            {
+                h2 style="margin-bottom: 1.5rem; font-size: 1.5rem; font-weight: 700;" {
+                    (title)
+                }
+
+                @if let Some(error_msg) = error {
+                    div class="error" style="margin-bottom: 1rem; padding: 0.75rem; background: #fee; border: 1px solid #fcc; border-radius: 4px; color: #c00;" {
+                        (error_msg)
+                    }
+                }
+
+                form hx-post=(form_action) hx-target=(format!("#{}", modal_id)) hx-swap="outerHTML" {
+                    (form_fields)
+
+                    div style="display: flex; gap: 0.5rem; justify-content: flex-end;" {
+                        button
+                            type="button"
+                            class="btn"
+                            style="background: white; border: 1px solid var(--gray-300);"
+                            onclick=(format!("document.getElementById('{}').remove()", modal_id))
+                        {
+                            "Cancel"
+                        }
+                        button type="submit" class="btn btn-primary" {
+                            (submit_label)
+                        }
+                    }
+                }
+            }
+        }
+        (PreEscaped(format!(r#"
+        <script>
+            document.getElementById('{}').addEventListener('click', function(e) {{
+                if (e.target === this) {{
+                    this.remove();
+                }}
+            }});
+        </script>
+        "#, modal_id)))
+    }
+}
+
+/// Table actions (Edit/Delete buttons)
+pub fn table_actions(
+    edit_url: &str,
+    delete_url: &str,
+    table_id: &str,
+    entity_label: &str,
+) -> Markup {
+    html! {
+        td style="text-align: right;" {
+            button
+                class="btn btn-sm"
+                hx-get=(edit_url)
+                hx-target="#modal-container"
+                hx-swap="innerHTML"
+                style="margin-right: 0.5rem;"
+            {
+                "Edit"
+            }
+            button
+                class="btn btn-sm btn-danger"
+                hx-post=(delete_url)
+                hx-target=(format!("#{}", table_id))
+                hx-swap="outerHTML"
+                hx-confirm=(format!("Are you sure you want to delete this {}?", entity_label))
+            {
+                "Delete"
+            }
+        }
+    }
+}

--- a/frontend/src/views/components/mod.rs
+++ b/frontend/src/views/components/mod.rs
@@ -1,3 +1,4 @@
+pub mod crud;
 pub mod error;
 pub mod sidebar;
 pub mod table;

--- a/frontend/src/views/pages/mod.rs
+++ b/frontend/src/views/pages/mod.rs
@@ -4,4 +4,5 @@ pub mod dashboard;
 pub mod events;
 pub mod matches;
 pub mod players;
+pub mod seasons;
 pub mod teams;

--- a/frontend/src/views/pages/seasons.rs
+++ b/frontend/src/views/pages/seasons.rs
@@ -1,0 +1,428 @@
+use maud::{html, Markup};
+
+use crate::service::seasons::{PagedResult, SeasonEntity, SeasonFilters, SortField, SortOrder};
+use crate::views::components::crud::{empty_state, modal_form, page_header, pagination, table_actions};
+
+/// Main seasons page with table and filters
+pub fn seasons_page(
+    result: &PagedResult<SeasonEntity>,
+    filters: &SeasonFilters,
+    sort_field: &SortField,
+    sort_order: &SortOrder,
+    events: &[(i64, String)],
+) -> Markup {
+    html! {
+        div class="card" {
+            // Header with title and create button
+            (page_header(
+                "Seasons",
+                "Manage seasons for events.",
+                "/seasons/new",
+                "+ New Season"
+            ))
+
+            // Filters
+            div style="margin-bottom: 1.5rem; padding: 1rem; background: var(--gray-50); border-radius: 8px;" {
+                form hx-get="/seasons/list" hx-target="#seasons-table" hx-swap="outerHTML" hx-trigger="submit, change delay:300ms" {
+                    div style="display: grid; grid-template-columns: 1fr 1fr auto; gap: 1rem; align-items: end;" {
+                        // Event filter
+                        div {
+                            label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                                "Filter by event"
+                            }
+                            select
+                                name="event_id"
+                                style="width: 100%; padding: 0.5rem; border: 1px solid var(--gray-300); border-radius: 4px;"
+                            {
+                                option value="" { "All events" }
+                                @for (id, name) in events {
+                                    option
+                                        value=(id)
+                                        selected[filters.event_id == Some(*id)]
+                                    {
+                                        (name)
+                                    }
+                                }
+                            }
+                        }
+
+                        // Year filter
+                        div {
+                            label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                                "Filter by year"
+                            }
+                            input
+                                type="number"
+                                name="year"
+                                value=[filters.year.as_ref()]
+                                placeholder="Enter year..."
+                                min="1900"
+                                max="2100"
+                                style="width: 100%; padding: 0.5rem; border: 1px solid var(--gray-300); border-radius: 4px;";
+                        }
+
+                        // Clear button
+                        div {
+                            button
+                                type="button"
+                                class="btn"
+                                style="background: white; border: 1px solid var(--gray-300);"
+                                hx-get="/seasons/list"
+                                hx-target="#seasons-table"
+                                hx-swap="outerHTML"
+                            {
+                                "Clear"
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Table
+            (season_list_content(result, filters, sort_field, sort_order))
+
+            // Modal container
+            div id="modal-container" {}
+        }
+    }
+}
+
+/// Seasons table content (for HTMX updates)
+pub fn season_list_content(
+    result: &PagedResult<SeasonEntity>,
+    filters: &SeasonFilters,
+    sort_field: &SortField,
+    sort_order: &SortOrder,
+) -> Markup {
+    html! {
+        div id="seasons-table" {
+            @if result.items.is_empty() {
+                (empty_state(
+                    "seasons",
+                    filters.event_id.is_some() || filters.year.is_some()
+                ))
+            } @else {
+                table class="table" {
+                    thead {
+                        tr {
+                            th {
+                                (sortable_header(
+                                    "ID",
+                                    &SortField::Id,
+                                    sort_field,
+                                    sort_order,
+                                    filters,
+                                ))
+                            }
+                            th {
+                                (sortable_header(
+                                    "Year",
+                                    &SortField::Year,
+                                    sort_field,
+                                    sort_order,
+                                    filters,
+                                ))
+                            }
+                            th { "Display Name" }
+                            th {
+                                (sortable_header(
+                                    "Event",
+                                    &SortField::Event,
+                                    sort_field,
+                                    sort_order,
+                                    filters,
+                                ))
+                            }
+                            th style="text-align: right;" { "Actions" }
+                        }
+                    }
+                    tbody {
+                        @for season in &result.items {
+                            tr {
+                                td { (season.id) }
+                                td { (season.year) }
+                                td {
+                                    @if let Some(display_name) = &season.display_name {
+                                        (display_name)
+                                    } @else {
+                                        span style="color: var(--gray-400); font-style: italic;" {
+                                            (format!("{} Season", season.year))
+                                        }
+                                    }
+                                }
+                                td { (&season.event_name) }
+                                (table_actions(
+                                    &format!("/seasons/{}/edit", season.id),
+                                    &build_delete_url(season.id, filters, sort_field, sort_order),
+                                    "seasons-table",
+                                    "season"
+                                ))
+                            }
+                        }
+                    }
+                }
+
+                // Pagination
+                (pagination(
+                    result,
+                    "seasons",
+                    |page| build_pagination_url(page, result.page_size, filters, sort_field, sort_order),
+                    "seasons-table"
+                ))
+            }
+        }
+    }
+}
+
+/// Sortable table header
+fn sortable_header(
+    label: &str,
+    field: &SortField,
+    current_sort: &SortField,
+    current_order: &SortOrder,
+    filters: &SeasonFilters,
+) -> Markup {
+    // Determine if this column is currently sorted
+    let is_active = matches!(
+        (field, current_sort),
+        (SortField::Id, SortField::Id)
+            | (SortField::Year, SortField::Year)
+            | (SortField::Event, SortField::Event)
+    );
+
+    // If this column is active, toggle the order; otherwise default to DESC for year, ASC for others
+    let next_order = if is_active {
+        current_order.toggle()
+    } else {
+        match field {
+            SortField::Year => SortOrder::Desc,
+            _ => SortOrder::Asc,
+        }
+    };
+
+    // Build the URL
+    let url = build_sort_url(field, &next_order, filters);
+
+    // Choose the indicator
+    let indicator = if is_active {
+        match current_order {
+            SortOrder::Asc => "↑",
+            SortOrder::Desc => "↓",
+        }
+    } else {
+        "↕"
+    };
+
+    html! {
+        button
+            class="sort-button"
+            hx-get=(url)
+            hx-target="#seasons-table"
+            hx-swap="outerHTML"
+            style="background: none; border: none; cursor: pointer; padding: 0; font-weight: 600; display: flex; align-items: center; gap: 0.25rem;"
+        {
+            (label)
+            span style=(if is_active { "font-size: 0.75rem; color: var(--primary-color);" } else { "font-size: 0.75rem;" }) {
+                (indicator)
+            }
+        }
+    }
+}
+
+/// Helper to build sort URLs
+fn build_sort_url(field: &SortField, order: &SortOrder, filters: &SeasonFilters) -> String {
+    let mut url = format!("/seasons/list?sort={}&order={}", field.as_str(), order.as_str());
+
+    if let Some(event_id) = filters.event_id {
+        url.push_str(&format!("&event_id={}", event_id));
+    }
+
+    if let Some(year) = filters.year {
+        url.push_str(&format!("&year={}", year));
+    }
+
+    url
+}
+
+/// Helper to build pagination URLs with filters and sorting
+fn build_pagination_url(
+    page: usize,
+    page_size: usize,
+    filters: &SeasonFilters,
+    sort_field: &SortField,
+    sort_order: &SortOrder,
+) -> String {
+    let mut url = format!(
+        "/seasons/list?page={}&page_size={}&sort={}&order={}",
+        page,
+        page_size,
+        sort_field.as_str(),
+        sort_order.as_str()
+    );
+
+    if let Some(event_id) = filters.event_id {
+        url.push_str(&format!("&event_id={}", event_id));
+    }
+
+    if let Some(year) = filters.year {
+        url.push_str(&format!("&year={}", year));
+    }
+
+    url
+}
+
+/// Helper to build delete URL with current filters and sorting
+fn build_delete_url(
+    season_id: i64,
+    filters: &SeasonFilters,
+    sort_field: &SortField,
+    sort_order: &SortOrder,
+) -> String {
+    let mut url = format!(
+        "/seasons/{}/delete?sort={}&order={}",
+        season_id,
+        sort_field.as_str(),
+        sort_order.as_str()
+    );
+
+    if let Some(event_id) = filters.event_id {
+        url.push_str(&format!("&event_id={}", event_id));
+    }
+
+    if let Some(year) = filters.year {
+        url.push_str(&format!("&year={}", year));
+    }
+
+    url
+}
+
+/// Create season modal
+pub fn season_create_modal(error: Option<&str>, events: &[(i64, String)]) -> Markup {
+    let form_fields = html! {
+        div style="margin-bottom: 1rem;" {
+            label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                "Event"
+                span style="color: red;" { "*" }
+            }
+            select
+                name="event_id"
+                required
+                autofocus
+                style="width: 100%; padding: 0.5rem; border: 1px solid var(--gray-300); border-radius: 4px;"
+            {
+                option value="" { "Select an event" }
+                @for (id, name) in events {
+                    option value=(id) {
+                        (name)
+                    }
+                }
+            }
+        }
+
+        div style="margin-bottom: 1rem;" {
+            label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                "Year"
+                span style="color: red;" { "*" }
+            }
+            input
+                type="number"
+                name="year"
+                required
+                min="1900"
+                max="2100"
+                placeholder="2024"
+                style="width: 100%; padding: 0.5rem; border: 1px solid var(--gray-300); border-radius: 4px;";
+        }
+
+        div style="margin-bottom: 1.5rem;" {
+            label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                "Display Name"
+            }
+            input
+                type="text"
+                name="display_name"
+                placeholder="e.g., 2024 Championship"
+                style="width: 100%; padding: 0.5rem; border: 1px solid var(--gray-300); border-radius: 4px;";
+            p style="font-size: 0.75rem; color: var(--gray-500); margin-top: 0.25rem;" {
+                "Optional: Custom display name (defaults to year)"
+            }
+        }
+    };
+
+    modal_form(
+        "season-modal",
+        "Create Season",
+        error,
+        "/seasons",
+        form_fields,
+        "Create Season"
+    )
+}
+
+/// Edit season modal
+pub fn season_edit_modal(
+    season: &SeasonEntity,
+    error: Option<&str>,
+    events: &[(i64, String)],
+) -> Markup {
+    let form_fields = html! {
+        div style="margin-bottom: 1rem;" {
+            label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                "Event"
+                span style="color: red;" { "*" }
+            }
+            select
+                name="event_id"
+                required
+                autofocus
+                style="width: 100%; padding: 0.5rem; border: 1px solid var(--gray-300); border-radius: 4px;"
+            {
+                option value="" { "Select an event" }
+                @for (id, name) in events {
+                    option value=(id) selected[*id == season.event_id] {
+                        (name)
+                    }
+                }
+            }
+        }
+
+        div style="margin-bottom: 1rem;" {
+            label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                "Year"
+                span style="color: red;" { "*" }
+            }
+            input
+                type="number"
+                name="year"
+                value=(season.year)
+                required
+                min="1900"
+                max="2100"
+                style="width: 100%; padding: 0.5rem; border: 1px solid var(--gray-300); border-radius: 4px;";
+        }
+
+        div style="margin-bottom: 1.5rem;" {
+            label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                "Display Name"
+            }
+            input
+                type="text"
+                name="display_name"
+                value=[season.display_name.as_ref()]
+                placeholder="e.g., 2024 Championship"
+                style="width: 100%; padding: 0.5rem; border: 1px solid var(--gray-300); border-radius: 4px;";
+            p style="font-size: 0.75rem; color: var(--gray-500); margin-top: 0.25rem;" {
+                "Optional: Custom display name (defaults to year)"
+            }
+        }
+    };
+
+    modal_form(
+        "season-modal",
+        "Edit Season",
+        error,
+        &format!("/seasons/{}", season.id),
+        form_fields,
+        "Save Changes"
+    )
+}


### PR DESCRIPTION
This pull request adds full CRUD (Create, Read, Update, Delete) support for managing "seasons" in the application, including backend service logic, HTTP routes, and integration with the frontend. It also improves the player deletion endpoint to reload the filtered and sorted player list after deletion.

**Seasons CRUD functionality:**

* Added a new `seasons` service module (`frontend/src/service/seasons.rs`) with support for creating, retrieving (with filtering, sorting, and pagination), updating, and deleting seasons, as well as fetching events for dropdowns.
* Implemented a new `seasons` route module (`frontend/src/routes/seasons.rs`) providing endpoints for listing, creating, editing, updating, and deleting seasons, with appropriate validation and error handling.
* Registered all new `seasons` HTTP routes in the main application router, enabling frontend access to the new endpoints.
* Added `seasons` to the list of available modules in both the `routes` and `service` modules for proper import and usage throughout the codebase. [[1]](diffhunk://#diff-8036b5ad93cfc7ae111007bfaca7c02c8a47f1ccdffc345043c8c91de9f77384R6) [[2]](diffhunk://#diff-d9d2666995f77de6d97d980953a9a92afddf67ea5397cb2a83e656afbc397455R5)

**Player deletion improvement:**

* Enhanced the player deletion endpoint to reload the filtered and sorted player list after a successful delete, ensuring the UI stays up-to-date with the current filters and sort order.