### PR TITLE
feat: Player Contract/Roster Management (Issue #116)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,22 @@ async fn main() -> Result<(), anyhow::Error> {
             "/team-participations/:id/delete",
             post(routes::seasons::team_participation_delete),
         )
+        .route(
+            "/team-participations/:id/roster",
+            get(routes::player_contracts::roster_get),
+        )
+        .route(
+            "/team-participations/:id/roster/add-player",
+            get(routes::player_contracts::roster_add_player_form),
+        )
+        .route(
+            "/team-participations/:id/roster",
+            post(routes::player_contracts::roster_add_player),
+        )
+        .route(
+            "/player-contracts/:id/delete",
+            post(routes::player_contracts::player_contract_delete),
+        )
         .route("/matches", get(routes::matches::matches_get))
         .route("/matches/list", get(routes::matches::matches_list_partial))
         .route("/matches/new", get(routes::matches::match_create_form))

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -3,6 +3,7 @@ pub mod countries;
 pub mod events;
 pub mod locale;
 pub mod matches;
+pub mod player_contracts;
 pub mod players;
 pub mod seasons;
 pub mod teams;

--- a/src/routes/player_contracts.rs
+++ b/src/routes/player_contracts.rs
@@ -1,0 +1,247 @@
+use axum::{
+    extract::{Path, State},
+    http::{HeaderMap, HeaderName},
+    response::{Html, IntoResponse},
+    Extension, Form,
+};
+use serde::Deserialize;
+
+use crate::app_state::AppState;
+use crate::auth::Session;
+use crate::i18n::TranslationContext;
+use crate::service::player_contracts;
+use crate::views::{
+    layout::admin_layout,
+    pages::roster::{add_player_modal, roster_page},
+};
+
+#[derive(Debug, Deserialize)]
+pub struct AddPlayerForm {
+    player_id: i64,
+}
+
+/// GET /team-participations/{id}/roster - Roster management page
+pub async fn roster_get(
+    Extension(session): Extension<Session>,
+    Extension(t): Extension<TranslationContext>,
+    State(state): State<AppState>,
+    Path(team_participation_id): Path<i64>,
+) -> impl IntoResponse {
+    // Get team participation context
+    let context =
+        match player_contracts::get_team_participation_context(&state.db, team_participation_id)
+            .await
+        {
+            Ok(Some(context)) => context,
+            Ok(None) => {
+                return Html(
+                    admin_layout(
+                        "Team Participation Not Found",
+                        &session,
+                        "/seasons",
+                        &t,
+                        crate::views::components::error::error_message(
+                            "Team participation not found",
+                        ),
+                    )
+                    .into_string(),
+                );
+            }
+            Err(e) => {
+                tracing::error!(
+                    "Failed to fetch team participation context for {}: {}",
+                    team_participation_id,
+                    e
+                );
+                return Html(
+                    admin_layout(
+                        "Error",
+                        &session,
+                        "/seasons",
+                        &t,
+                        crate::views::components::error::error_message(
+                            "Failed to load team participation",
+                        ),
+                    )
+                    .into_string(),
+                );
+            }
+        };
+
+    // Get current roster
+    let roster = match player_contracts::get_roster(&state.db, team_participation_id).await {
+        Ok(roster) => roster,
+        Err(e) => {
+            tracing::error!(
+                "Failed to fetch roster for team participation {}: {}",
+                team_participation_id,
+                e
+            );
+            return Html(
+                admin_layout(
+                    "Error",
+                    &session,
+                    &format!("/seasons/{}", context.season_id),
+                    &t,
+                    crate::views::components::error::error_message("Failed to load roster"),
+                )
+                .into_string(),
+            );
+        }
+    };
+
+    let content = roster_page(&t, &context, &roster);
+    Html(admin_layout("Roster Management", &session, "/seasons", &t, content).into_string())
+}
+
+/// GET /team-participations/{id}/roster/add-player - Form/modal to add player
+pub async fn roster_add_player_form(
+    Extension(t): Extension<TranslationContext>,
+    State(state): State<AppState>,
+    Path(team_participation_id): Path<i64>,
+) -> impl IntoResponse {
+    let available_players =
+        player_contracts::get_available_players(&state.db, team_participation_id)
+            .await
+            .unwrap_or_default();
+
+    Html(add_player_modal(&t, team_participation_id, None, &available_players).into_string())
+}
+
+/// POST /team-participations/{id}/roster - Add player to roster
+pub async fn roster_add_player(
+    Extension(t): Extension<TranslationContext>,
+    State(state): State<AppState>,
+    Path(team_participation_id): Path<i64>,
+    Form(form): Form<AddPlayerForm>,
+) -> axum::response::Response {
+    // Get available players for form re-render on error
+    let available_players =
+        player_contracts::get_available_players(&state.db, team_participation_id)
+            .await
+            .unwrap_or_default();
+
+    // Check if player is already in roster
+    match player_contracts::is_player_in_roster(&state.db, team_participation_id, form.player_id)
+        .await
+    {
+        Ok(true) => {
+            return Html(
+                add_player_modal(
+                    &t,
+                    team_participation_id,
+                    Some("This player is already in the roster"),
+                    &available_players,
+                )
+                .into_string(),
+            )
+            .into_response();
+        }
+        Err(e) => {
+            tracing::error!("Failed to check player in roster: {}", e);
+            return Html(
+                add_player_modal(
+                    &t,
+                    team_participation_id,
+                    Some("Failed to check player status"),
+                    &available_players,
+                )
+                .into_string(),
+            )
+            .into_response();
+        }
+        _ => {}
+    }
+
+    // Add player to roster
+    match player_contracts::add_player_to_roster(&state.db, team_participation_id, form.player_id)
+        .await
+    {
+        Ok(_) => {
+            // Return HTMX redirect to roster page
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                HeaderName::from_static("hx-redirect"),
+                format!("/team-participations/{}/roster", team_participation_id)
+                    .parse()
+                    .unwrap(),
+            );
+            (headers, Html("".to_string())).into_response()
+        }
+        Err(e) => {
+            tracing::error!("Failed to add player to roster: {}", e);
+            Html(
+                add_player_modal(
+                    &t,
+                    team_participation_id,
+                    Some("Failed to add player. Please try again."),
+                    &available_players,
+                )
+                .into_string(),
+            )
+            .into_response()
+        }
+    }
+}
+
+/// POST /player-contracts/{id}/delete - Remove player from roster
+pub async fn player_contract_delete(
+    State(state): State<AppState>,
+    Path(player_contract_id): Path<i64>,
+) -> axum::response::Response {
+    // Get team_participation_id before deleting for redirect
+    let team_participation_id = match player_contracts::get_team_participation_id_for_contract(
+        &state.db,
+        player_contract_id,
+    )
+    .await
+    {
+        Ok(Some(id)) => id,
+        Ok(None) => {
+            return Html(
+                crate::views::components::error::error_message("Player contract not found")
+                    .into_string(),
+            )
+            .into_response();
+        }
+        Err(e) => {
+            tracing::error!("Failed to fetch player contract: {}", e);
+            return Html(
+                crate::views::components::error::error_message(
+                    "Failed to remove player from roster",
+                )
+                .into_string(),
+            )
+            .into_response();
+        }
+    };
+
+    match player_contracts::remove_player_from_roster(&state.db, player_contract_id).await {
+        Ok(true) => {
+            // Return HTMX redirect to roster page
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                HeaderName::from_static("hx-redirect"),
+                format!("/team-participations/{}/roster", team_participation_id)
+                    .parse()
+                    .unwrap(),
+            );
+            (headers, Html("".to_string())).into_response()
+        }
+        Ok(false) => Html(
+            crate::views::components::error::error_message("Player contract not found")
+                .into_string(),
+        )
+        .into_response(),
+        Err(e) => {
+            tracing::error!("Failed to remove player from roster: {}", e);
+            Html(
+                crate::views::components::error::error_message(
+                    "Failed to remove player from roster",
+                )
+                .into_string(),
+            )
+            .into_response()
+        }
+    }
+}

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -2,6 +2,7 @@ pub mod countries;
 pub mod dashboard;
 pub mod events;
 pub mod matches;
+pub mod player_contracts;
 pub mod players;
 pub mod seasons;
 pub mod team_participations;

--- a/src/service/player_contracts.rs
+++ b/src/service/player_contracts.rs
@@ -1,0 +1,203 @@
+use sqlx::{Row, SqlitePool};
+
+/// Player in a roster with additional details
+#[derive(Debug, Clone)]
+pub struct PlayerInRoster {
+    pub player_contract_id: i64, // ID of the player_contract record
+    #[allow(dead_code)]
+    pub player_id: i64,
+    pub player_name: String,
+    #[allow(dead_code)]
+    pub country_id: i64,
+    pub country_name: String,
+    pub country_iso2_code: String,
+    pub photo_path: Option<String>,
+}
+
+/// Team participation context for roster page header
+#[derive(Debug, Clone)]
+pub struct TeamParticipationContext {
+    pub team_participation_id: i64,
+    #[allow(dead_code)]
+    pub team_id: i64,
+    pub team_name: String,
+    pub country_iso2_code: Option<String>,
+    pub season_id: i64,
+    pub season_year: i64,
+    pub season_display_name: Option<String>,
+    #[allow(dead_code)]
+    pub event_id: i64,
+    pub event_name: String,
+}
+
+/// Get all players in a roster for a team participation
+pub async fn get_roster(
+    db: &SqlitePool,
+    team_participation_id: i64,
+) -> Result<Vec<PlayerInRoster>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT
+            pc.id as player_contract_id,
+            p.id as player_id,
+            p.name as player_name,
+            p.photo_path,
+            c.id as country_id,
+            c.name as country_name,
+            c.iso2Code as country_iso2_code
+        FROM player_contract pc
+        INNER JOIN player p ON pc.player_id = p.id
+        INNER JOIN country c ON p.country_id = c.id
+        WHERE pc.team_participation_id = ?
+        ORDER BY p.name ASC",
+    )
+    .bind(team_participation_id)
+    .fetch_all(db)
+    .await?;
+
+    let players = rows
+        .into_iter()
+        .map(|row| PlayerInRoster {
+            player_contract_id: row.get("player_contract_id"),
+            player_id: row.get("player_id"),
+            player_name: row.get("player_name"),
+            country_id: row.get("country_id"),
+            country_name: row.get("country_name"),
+            country_iso2_code: row.get("country_iso2_code"),
+            photo_path: row.get("photo_path"),
+        })
+        .collect();
+
+    Ok(players)
+}
+
+/// Get team participation context (team, event, season info)
+pub async fn get_team_participation_context(
+    db: &SqlitePool,
+    team_participation_id: i64,
+) -> Result<Option<TeamParticipationContext>, sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT
+            tp.id as team_participation_id,
+            t.id as team_id,
+            t.name as team_name,
+            c.iso2Code as country_iso2_code,
+            s.id as season_id,
+            s.year as season_year,
+            s.display_name as season_display_name,
+            e.id as event_id,
+            e.name as event_name
+        FROM team_participation tp
+        INNER JOIN team t ON tp.team_id = t.id
+        LEFT JOIN country c ON t.country_id = c.id
+        INNER JOIN season s ON tp.season_id = s.id
+        INNER JOIN event e ON s.event_id = e.id
+        WHERE tp.id = ?",
+    )
+    .bind(team_participation_id)
+    .fetch_optional(db)
+    .await?;
+
+    Ok(row.map(|row| TeamParticipationContext {
+        team_participation_id: row.get("team_participation_id"),
+        team_id: row.get("team_id"),
+        team_name: row.get("team_name"),
+        country_iso2_code: row.get("country_iso2_code"),
+        season_id: row.get("season_id"),
+        season_year: row.get("season_year"),
+        season_display_name: row.get("season_display_name"),
+        event_id: row.get("event_id"),
+        event_name: row.get("event_name"),
+    }))
+}
+
+/// Get players not yet in the roster (available to add)
+pub async fn get_available_players(
+    db: &SqlitePool,
+    team_participation_id: i64,
+) -> Result<Vec<(i64, String, String)>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT p.id, p.name, c.name as country_name
+        FROM player p
+        INNER JOIN country c ON p.country_id = c.id
+        WHERE p.id NOT IN (
+            SELECT player_id FROM player_contract WHERE team_participation_id = ?
+        )
+        ORDER BY p.name ASC",
+    )
+    .bind(team_participation_id)
+    .fetch_all(db)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| {
+            (
+                row.get("id"),
+                row.get("name"),
+                row.get::<String, _>("country_name"),
+            )
+        })
+        .collect())
+}
+
+/// Check if a player is already in a roster
+pub async fn is_player_in_roster(
+    db: &SqlitePool,
+    team_participation_id: i64,
+    player_id: i64,
+) -> Result<bool, sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT COUNT(*) as count
+        FROM player_contract
+        WHERE team_participation_id = ? AND player_id = ?",
+    )
+    .bind(team_participation_id)
+    .bind(player_id)
+    .fetch_one(db)
+    .await?;
+
+    let count: i64 = row.get("count");
+    Ok(count > 0)
+}
+
+/// Add a player to a roster (create player_contract)
+pub async fn add_player_to_roster(
+    db: &SqlitePool,
+    team_participation_id: i64,
+    player_id: i64,
+) -> Result<i64, sqlx::Error> {
+    let result =
+        sqlx::query("INSERT INTO player_contract (team_participation_id, player_id) VALUES (?, ?)")
+            .bind(team_participation_id)
+            .bind(player_id)
+            .execute(db)
+            .await?;
+
+    Ok(result.last_insert_rowid())
+}
+
+/// Remove a player from a roster (delete player_contract)
+pub async fn remove_player_from_roster(
+    db: &SqlitePool,
+    player_contract_id: i64,
+) -> Result<bool, sqlx::Error> {
+    let result = sqlx::query("DELETE FROM player_contract WHERE id = ?")
+        .bind(player_contract_id)
+        .execute(db)
+        .await?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Get team_participation_id for a player_contract (useful for redirects after delete)
+pub async fn get_team_participation_id_for_contract(
+    db: &SqlitePool,
+    player_contract_id: i64,
+) -> Result<Option<i64>, sqlx::Error> {
+    let row = sqlx::query("SELECT team_participation_id FROM player_contract WHERE id = ?")
+        .bind(player_contract_id)
+        .fetch_optional(db)
+        .await?;
+
+    Ok(row.map(|r| r.get("team_participation_id")))
+}

--- a/src/views/pages/mod.rs
+++ b/src/views/pages/mod.rs
@@ -4,6 +4,7 @@ pub mod dashboard;
 pub mod events;
 pub mod matches;
 pub mod players;
+pub mod roster;
 pub mod season_detail;
 pub mod seasons;
 pub mod teams;

--- a/src/views/pages/roster.rs
+++ b/src/views/pages/roster.rs
@@ -1,0 +1,230 @@
+use maud::{html, Markup};
+
+use crate::i18n::TranslationContext;
+use crate::service::player_contracts::{PlayerInRoster, TeamParticipationContext};
+use crate::views::components::confirm::{confirm_attrs, ConfirmVariant};
+use crate::views::components::crud::modal_form_i18n;
+
+/// Main roster management page
+pub fn roster_page(
+    _t: &TranslationContext,
+    context: &TeamParticipationContext,
+    roster: &[PlayerInRoster],
+) -> Markup {
+    html! {
+        div class="card" {
+            // Header with back button and context
+            div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;" {
+                div style="display: flex; align-items: center; gap: 1rem;" {
+                    a
+                        href=(format!("/seasons/{}", context.season_id))
+                        class="btn btn-secondary"
+                    {
+                        (format!("← {}", "Back to Season"))
+                    }
+                    h1 style="font-size: 2rem; font-weight: 700; margin: 0;" {
+                        "Roster Management"
+                    }
+                }
+            }
+
+            // Context info card
+            (context_card(context))
+
+            // Roster section
+            div style="margin-top: 2rem;" {
+                div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;" {
+                    h2 style="font-size: 1.5rem; font-weight: 700; margin: 0;" {
+                        (format!("Players ({} total)", roster.len()))
+                    }
+                    button
+                        class="btn btn-primary"
+                        hx-get=(format!("/team-participations/{}/roster/add-player", context.team_participation_id))
+                        hx-target="#modal-container"
+                        hx-swap="innerHTML"
+                    {
+                        "+ Add Player"
+                    }
+                }
+
+                @if roster.is_empty() {
+                    (empty_roster_state())
+                } @else {
+                    (roster_table(roster))
+                }
+            }
+
+            // Modal container
+            div id="modal-container" {}
+        }
+    }
+}
+
+/// Context card showing team, event, and season info
+fn context_card(context: &TeamParticipationContext) -> Markup {
+    html! {
+        div style="padding: 1.5rem; background: var(--gray-50); border-radius: 8px;" {
+            div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem;" {
+                div {
+                    div style="color: var(--gray-600); font-size: 0.875rem; margin-bottom: 0.25rem;" {
+                        "Team"
+                    }
+                    div style="font-weight: 600; display: flex; align-items: center; gap: 0.5rem;" {
+                        @if let Some(iso2) = &context.country_iso2_code {
+                            img
+                                src=(format!("https://flagcdn.com/w40/{}.png", iso2.to_lowercase()))
+                                alt=(context.team_name)
+                                style="width: 24px; height: 18px; object-fit: cover; border: 1px solid var(--gray-300); border-radius: 2px;"
+                                onerror="this.style.display='none'";
+                        }
+                        (context.team_name)
+                    }
+                }
+                div {
+                    div style="color: var(--gray-600); font-size: 0.875rem; margin-bottom: 0.25rem;" {
+                        "Event"
+                    }
+                    div style="font-weight: 600;" {
+                        (context.event_name)
+                    }
+                }
+                div {
+                    div style="color: var(--gray-600); font-size: 0.875rem; margin-bottom: 0.25rem;" {
+                        "Season"
+                    }
+                    div style="font-weight: 600;" {
+                        @if let Some(display_name) = &context.season_display_name {
+                            (display_name)
+                        } @else {
+                            (format!("{} Season", context.season_year))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Roster table showing all players
+fn roster_table(roster: &[PlayerInRoster]) -> Markup {
+    html! {
+        table class="table" {
+            thead {
+                tr {
+                    th { "Player" }
+                    th { "Nationality" }
+                    th style="text-align: right;" { "Actions" }
+                }
+            }
+            tbody {
+                @for player in roster {
+                    tr {
+                        td {
+                            div style="display: flex; align-items: center; gap: 0.5rem;" {
+                                @if let Some(_photo) = &player.photo_path {
+                                    img
+                                        src="https://via.placeholder.com/40"
+                                        alt=(player.player_name)
+                                        style="width: 40px; height: 40px; border-radius: 50%; object-fit: cover;"
+                                        onerror="this.style.display='none'";
+                                }
+                                span style="font-weight: 500;" {
+                                    (player.player_name)
+                                }
+                            }
+                        }
+                        td {
+                            div style="display: flex; align-items: center; gap: 0.5rem;" {
+                                img
+                                    src=(format!("https://flagcdn.com/w40/{}.png", player.country_iso2_code.to_lowercase()))
+                                    alt=(player.country_name)
+                                    style="width: 24px; height: 18px; object-fit: cover; border: 1px solid var(--gray-300); border-radius: 2px;"
+                                    onerror="this.style.display='none'";
+                                (player.country_name)
+                            }
+                        }
+                        td style="text-align: right;" {
+                            button
+                                class="btn btn-sm btn-danger"
+                                hx-post=(format!("/player-contracts/{}/delete", player.player_contract_id))
+                                hx-confirm-custom=(confirm_attrs(
+                                    "Remove Player",
+                                    &format!("Are you sure you want to remove {} from the roster?", player.player_name),
+                                    ConfirmVariant::Danger,
+                                    Some("Remove"),
+                                    Some("Cancel")
+                                ))
+                            {
+                                "Remove"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Empty state when no players in roster
+fn empty_roster_state() -> Markup {
+    html! {
+        div style="padding: 3rem; text-align: center; background: var(--gray-50); border-radius: 8px; border: 2px dashed var(--gray-300);" {
+            div style="font-size: 3rem; margin-bottom: 1rem; opacity: 0.3;" {
+                "👤"
+            }
+            p style="color: var(--gray-600); font-size: 1.125rem; margin-bottom: 0.5rem; font-weight: 500;" {
+                "No players in roster"
+            }
+            p style="font-size: 0.875rem; color: var(--gray-500);" {
+                "Click the 'Add Player' button to build your team roster"
+            }
+        }
+    }
+}
+
+/// Modal form to add a player to the roster
+pub fn add_player_modal(
+    t: &TranslationContext,
+    team_participation_id: i64,
+    error: Option<&str>,
+    available_players: &[(i64, String, String)],
+) -> Markup {
+    let form_fields = html! {
+        div style="margin-bottom: 1.5rem;" {
+            label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
+                "Select Player"
+                span style="color: red; margin-left: 0.25rem;" { "*" }
+            }
+
+            @if available_players.is_empty() {
+                div style="padding: 1rem; background: var(--gray-100); border-radius: 4px; color: var(--gray-600); text-align: center;" {
+                    "No available players to add. All players are already in the roster."
+                }
+            } @else {
+                select
+                    name="player_id"
+                    required
+                    autofocus
+                    style="width: 100%; padding: 0.75rem; border: 1px solid var(--gray-300); border-radius: 4px; font-size: 1rem;"
+                {
+                    option value="" { "-- Select a player --" }
+                    @for (id, name, country) in available_players {
+                        option value=(id) {
+                            (format!("{} ({})", name, country))
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    modal_form_i18n(
+        "add-player-modal",
+        "Add Player to Roster",
+        error,
+        &format!("/team-participations/{}/roster", team_participation_id),
+        form_fields,
+        "Add Player",
+        &t.messages.common_cancel().to_string(),
+    )
+}

--- a/src/views/pages/season_detail.rs
+++ b/src/views/pages/season_detail.rs
@@ -125,12 +125,12 @@ fn season_info_card(
     }
 }
 
-/// Teams list in grid layout with flags and remove buttons
+/// Teams list in grid layout with flags and action buttons
 fn teams_list(t: &TranslationContext, teams: &[TeamParticipationEntity]) -> Markup {
     html! {
-        div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem;" {
+        div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 1rem;" {
             @for team in teams {
-                div style="padding: 1rem; border: 1px solid var(--gray-200); border-radius: 8px; display: flex; justify-content: space-between; align-items: center; transition: box-shadow 0.2s; cursor: pointer;"
+                div style="padding: 1rem; border: 1px solid var(--gray-200); border-radius: 8px; display: flex; flex-direction: column; gap: 1rem; transition: box-shadow 0.2s;"
                      onmouseover="this.style.boxShadow='0 2px 8px rgba(0,0,0,0.1)'"
                      onmouseout="this.style.boxShadow='none'"
                 {
@@ -146,23 +146,31 @@ fn teams_list(t: &TranslationContext, teams: &[TeamParticipationEntity]) -> Mark
                             (team.team_name)
                         }
                     }
-                    button
-                        class="btn btn-sm btn-danger"
-                        hx-post=(format!("/team-participations/{}/delete", team.id))
-                        hx-confirm-custom=(confirm_attrs(
-                            &t.messages.seasons_remove_team().to_string(),
-                            &format!("{} {} {}",
-                                t.messages.seasons_confirm_remove_team_1(),
-                                team.team_name,
-                                t.messages.seasons_confirm_remove_team_2()
-                            ),
-                            ConfirmVariant::Danger,
-                            Some(&t.messages.common_remove().to_string()),
-                            Some(&t.messages.common_cancel().to_string())
-                        ))
-                        onclick="event.stopPropagation()"
-                    {
-                        (t.messages.common_remove())
+                    div style="display: flex; gap: 0.5rem;" {
+                        a
+                            href=(format!("/team-participations/{}/roster", team.id))
+                            class="btn btn-sm btn-primary"
+                            style="flex: 1;"
+                        {
+                            "Manage Roster"
+                        }
+                        button
+                            class="btn btn-sm btn-danger"
+                            hx-post=(format!("/team-participations/{}/delete", team.id))
+                            hx-confirm-custom=(confirm_attrs(
+                                &t.messages.seasons_remove_team().to_string(),
+                                &format!("{} {} {}",
+                                    t.messages.seasons_confirm_remove_team_1(),
+                                    team.team_name,
+                                    t.messages.seasons_confirm_remove_team_2()
+                                ),
+                                ConfirmVariant::Danger,
+                                Some(&t.messages.common_remove().to_string()),
+                                Some(&t.messages.common_cancel().to_string())
+                            ))
+                        {
+                            (t.messages.common_remove())
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Implement roster management system for assigning players to team participations. This enables building team rosters for specific seasons/tournaments.

**Key Concept**: Rosters are tied to team_participation (a team in a specific season), NOT to teams directly. National teams have different rosters for each tournament.

## Changes

### Service Layer (`src/service/player_contracts.rs`)
- `get_roster()` - Fetch all players in a roster with details
- `get_team_participation_context()` - Get team, event, season info
- `get_available_players()` - Get players not yet in roster
- `is_player_in_roster()` - Prevent duplicate players
- `add_player_to_roster()` - Add player to roster
- `remove_player_from_roster()` - Remove player from roster
- Helper functions for redirects and lookups

### Routes (`src/routes/player_contracts.rs`)
- `GET /team-participations/:id/roster` - Roster management page
- `GET /team-participations/:id/roster/add-player` - Add player modal
- `POST /team-participations/:id/roster` - Add player action
- `POST /player-contracts/:id/delete` - Remove player action

### Views (`src/views/pages/roster.rs`)
- Roster management page with context card
- Roster table with player names and nationality flags
- Empty state when no players in roster
- Add player modal with available players dropdown
- Confirmation dialogs for player removal

### Integration
- Added "Manage Roster" button to team cards in season detail page
- Registered all routes in main.rs
- Updated module exports

## Features
✅ Roster management per team participation  
✅ Context display (team, event, season)  
✅ Duplicate player validation  
✅ Available players filtering  
✅ HTMX modals and smooth UX  
✅ Country flags for teams and players  
✅ Empty states with helpful messages

## Testing Workflow
This feature enables the full testing workflow:
1. Create event → season
2. Create teams
3. Add teams to season (team participations)
4. Create players
5. **Build rosters (this feature)**
6. Create matches between teams
7. Record score events with rostered players

## Build Status
- ✅ `cargo check` - passes
- ✅ `cargo fmt` - formatted
- ✅ `cargo clippy` - no warnings
- ✅ `cargo build` - successful

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)