### PR TITLE
refactor: simplification sweep — toast helper, SVG constant, import cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create, update, and delete operations for teams, players, events, seasons, and matches now show a localized success toast notification confirming the action completed, using the pre-existing toast web component and i18n message keys (#189)
 
 ### Changed
+- Extracted `with_toast_success` helper in `htmx.rs` to replace 9 repeated `HeaderMap::new() / insert / into_response()` blocks across the route handlers — each success path now reads as a single call (#simplify)
+- Extracted `AVATAR_FALLBACK_SVG` constant to eliminate the same 200-character URL-encoded SVG string duplicated across `player_detail.rs`, `players.rs`, and `roster.rs` (#simplify)
+- `season_update` now uses the `htmx_reload_table` helper instead of an equivalent inline HTML string, consistent with all other update handlers (#simplify)
+- Moved `HeaderMap` / `HeaderName` imports to module level in `events.rs`, `teams.rs`, and `players/handlers.rs` where they were incorrectly declared inside function bodies (#simplify)
 - Login page now respects the user's language selection — title, field labels, button, and error messages are all translated (Czech and English) instead of being hardcoded in English (#185)
 - Delete confirmation dialogs now show the exact item name being deleted (e.g. "Delete 'John Smith'") instead of a generic "Delete Player", preventing accidental deletions of the wrong item (#188)
 - Player photo in roster now uses the actual stored photo URL instead of a broken external placeholder service (#200)

--- a/src/routes/events.rs
+++ b/src/routes/events.rs
@@ -16,7 +16,10 @@ use crate::validation::validate_name;
 use axum::http::{HeaderMap, HeaderName};
 
 use crate::views::{
-    components::{error::error_message, htmx::{htmx_reload_table, with_toast_success}},
+    components::{
+        error::error_message,
+        htmx::{htmx_reload_table, with_toast_success},
+    },
     layout::admin_layout,
     pages::event_detail::event_detail_page,
     pages::events::{event_create_modal, event_edit_modal, event_list_content, events_page},

--- a/src/routes/events.rs
+++ b/src/routes/events.rs
@@ -13,8 +13,10 @@ use crate::service::{
     events::{self, CreateEventEntity, EventFilters, UpdateEventEntity},
 };
 use crate::validation::validate_name;
+use axum::http::{HeaderMap, HeaderName};
+
 use crate::views::{
-    components::{error::error_message, htmx::htmx_reload_table},
+    components::{error::error_message, htmx::{htmx_reload_table, with_toast_success}},
     layout::admin_layout,
     pages::event_detail::event_detail_page,
     pages::events::{event_create_modal, event_edit_modal, event_list_content, events_page},
@@ -223,8 +225,6 @@ pub async fn event_create(
     .await
     {
         Ok(_) => {
-            use axum::http::header::{HeaderMap, HeaderName};
-
             // Return HTMX response to close modal and reload table
             // Trigger entity-created event for dashboard stats update
             let mut headers = HeaderMap::new();
@@ -348,13 +348,10 @@ pub async fn event_update(
     {
         Ok(true) => {
             // Return HTMX response to close modal and reload table
-            use axum::http::header::{HeaderMap, HeaderName};
-            let mut headers = HeaderMap::new();
-            headers.insert(
-                HeaderName::from_static("hx-toast-success"),
-                t.messages.events_updated().to_string().parse().unwrap(),
-            );
-            (headers, htmx_reload_table("/events/list", "events-table")).into_response()
+            with_toast_success(
+                &t.messages.events_updated().to_string(),
+                htmx_reload_table("/events/list", "events-table"),
+            )
         }
         Ok(false) => Html(error_message(&t, t.messages.error_event_not_found()).into_string())
             .into_response(),
@@ -405,13 +402,10 @@ pub async fn event_delete(
     match events::delete_event(&state.db, id).await {
         Ok(true) => {
             // Return HTMX response to reload table
-            use axum::http::header::{HeaderMap, HeaderName};
-            let mut headers = HeaderMap::new();
-            headers.insert(
-                HeaderName::from_static("hx-toast-success"),
-                t.messages.events_deleted().to_string().parse().unwrap(),
-            );
-            (headers, htmx_reload_table("/events/list", "events-table")).into_response()
+            with_toast_success(
+                &t.messages.events_deleted().to_string(),
+                htmx_reload_table("/events/list", "events-table"),
+            )
         }
         Ok(false) => Html(
             crate::views::components::error::error_message(&t, t.messages.error_event_not_found())

--- a/src/routes/matches/crud.rs
+++ b/src/routes/matches/crud.rs
@@ -11,7 +11,7 @@ use crate::business;
 use crate::i18n::TranslationContext;
 use crate::service::matches::{self, CreateMatchEntity, UpdateMatchEntity};
 use crate::views::{
-    components::htmx::htmx_reload_table,
+    components::htmx::{htmx_reload_table, with_toast_success},
     pages::matches::{match_create_modal, match_edit_modal},
 };
 
@@ -107,8 +107,6 @@ pub async fn match_create(
     .await
     {
         Ok(_) => {
-            use axum::http::header::{HeaderMap, HeaderName};
-
             // Return HTMX response to close modal and reload table
             // Trigger entity-created event for dashboard stats update
             let mut headers = HeaderMap::new();
@@ -328,16 +326,10 @@ pub async fn match_delete(
     match matches::delete_match(&state.db, id).await {
         Ok(true) => {
             // Redirect to matches list using HTMX redirect header
-            let mut headers = HeaderMap::new();
-            headers.insert(
-                HeaderName::from_static("hx-toast-success"),
-                t.messages.matches_deleted().to_string().parse().unwrap(),
-            );
-            (
-                headers,
+            with_toast_success(
+                &t.messages.matches_deleted().to_string(),
                 Html(r#"<div hx-redirect="/matches"></div>"#.to_string()),
             )
-                .into_response()
         }
         Ok(false) => Html(
             crate::views::components::error::error_message(&t, t.messages.error_match_not_found())

--- a/src/routes/players/handlers.rs
+++ b/src/routes/players/handlers.rs
@@ -1,5 +1,6 @@
 use axum::{
     extract::{Multipart, Path, Query, State},
+    http::{HeaderMap, HeaderName},
     response::{Html, IntoResponse},
     Extension,
 };
@@ -15,7 +16,7 @@ use crate::service::{
 use crate::views::{
     components::{
         error::error_message,
-        htmx::{htmx_reload_page, htmx_reload_table},
+        htmx::{htmx_reload_page, htmx_reload_table, with_toast_success},
     },
     layout::admin_layout,
     pages::player_detail::player_detail_page,
@@ -190,8 +191,6 @@ pub async fn player_create(
     State(state): State<AppState>,
     mut multipart: Multipart,
 ) -> impl IntoResponse {
-    use axum::http::header::{HeaderMap, HeaderName};
-
     // Get countries for form re-render on error
     let countries = match countries::get_countries_simple(&state.db).await {
         Ok(countries) => countries,
@@ -377,13 +376,10 @@ pub async fn player_update(
     {
         Ok(true) => {
             // Return HTMX response to close modal and reload page to show updated data
-            use axum::http::header::{HeaderMap, HeaderName};
-            let mut headers = HeaderMap::new();
-            headers.insert(
-                HeaderName::from_static("hx-toast-success"),
-                t.messages.players_updated().to_string().parse().unwrap(),
-            );
-            (headers, htmx_reload_page()).into_response()
+            with_toast_success(
+                &t.messages.players_updated().to_string(),
+                htmx_reload_page(),
+            )
         }
         Ok(false) => Html(
             player_edit_modal(
@@ -482,20 +478,13 @@ pub async fn player_delete(
                 }
             };
 
-            use axum::http::header::{HeaderMap, HeaderName};
-            let mut headers = HeaderMap::new();
-            headers.insert(
-                HeaderName::from_static("hx-toast-success"),
-                t.messages.players_deleted().to_string().parse().unwrap(),
-            );
-            (
-                headers,
+            with_toast_success(
+                &t.messages.players_deleted().to_string(),
                 Html(
                     player_list_content(&session, &t, &result, &filters, &sort_field, &sort_order)
                         .into_string(),
                 ),
             )
-                .into_response()
         }
         Ok(false) => Html(
             crate::views::components::error::error_message(&t, t.messages.error_player_not_found())

--- a/src/routes/seasons.rs
+++ b/src/routes/seasons.rs
@@ -15,7 +15,10 @@ use crate::service::{
     seasons::{self, CreateSeasonEntity, SeasonFilters, SortField, SortOrder, UpdateSeasonEntity},
 };
 use crate::views::{
-    components::{error::error_message, htmx::{htmx_reload_table, with_toast_success}},
+    components::{
+        error::error_message,
+        htmx::{htmx_reload_table, with_toast_success},
+    },
     layout::admin_layout,
     pages::season_detail::{add_team_modal, season_detail_page},
     pages::seasons::{season_create_modal, season_edit_modal, season_list_content, seasons_page},

--- a/src/routes/seasons.rs
+++ b/src/routes/seasons.rs
@@ -15,7 +15,7 @@ use crate::service::{
     seasons::{self, CreateSeasonEntity, SeasonFilters, SortField, SortOrder, UpdateSeasonEntity},
 };
 use crate::views::{
-    components::{error::error_message, htmx::htmx_reload_table},
+    components::{error::error_message, htmx::{htmx_reload_table, with_toast_success}},
     layout::admin_layout,
     pages::season_detail::{add_team_modal, season_detail_page},
     pages::seasons::{season_create_modal, season_edit_modal, season_list_content, seasons_page},
@@ -333,8 +333,6 @@ pub async fn season_create(
     .await
     {
         Ok(_) => {
-            use axum::http::header::{HeaderMap, HeaderName};
-
             // Return HTMX response based on context
             // Trigger entity-created event for dashboard stats update
             let mut headers = HeaderMap::new();
@@ -511,16 +509,10 @@ pub async fn season_update(
     {
         Ok(true) => {
             // Return HTMX response to close modal and reload table
-            let mut headers = HeaderMap::new();
-            headers.insert(
-                HeaderName::from_static("hx-toast-success"),
-                t.messages.seasons_updated().to_string().parse().unwrap(),
-            );
-            (
-                headers,
-                Html("<div hx-get=\"/seasons/list\" hx-target=\"#seasons-table\" hx-trigger=\"load\" hx-swap=\"outerHTML\"></div>".to_string()),
+            with_toast_success(
+                &t.messages.seasons_updated().to_string(),
+                htmx_reload_table("/seasons/list", "seasons-table"),
             )
-                .into_response()
         }
         Ok(false) => Html(error_message(&t, t.messages.error_season_not_found()).into_string())
             .into_response(),
@@ -599,19 +591,13 @@ pub async fn season_delete(
                 }
             };
 
-            let mut headers = HeaderMap::new();
-            headers.insert(
-                HeaderName::from_static("hx-toast-success"),
-                t.messages.seasons_deleted().to_string().parse().unwrap(),
-            );
-            (
-                headers,
+            with_toast_success(
+                &t.messages.seasons_deleted().to_string(),
                 Html(
                     season_list_content(&session, &t, &result, &filters, &sort_field, &sort_order)
                         .into_string(),
                 ),
             )
-                .into_response()
         }
         Ok(false) => Html(
             crate::views::components::error::error_message(&t, t.messages.error_season_not_found())

--- a/src/routes/teams.rs
+++ b/src/routes/teams.rs
@@ -1,5 +1,6 @@
 use axum::{
     extract::{Path, Query, State},
+    http::{HeaderMap, HeaderName},
     response::{Html, IntoResponse},
     Extension, Form,
 };
@@ -14,7 +15,7 @@ use crate::service::{
 };
 use crate::validation::validate_name;
 use crate::views::{
-    components::{error::error_message, htmx::htmx_reload_table},
+    components::{error::error_message, htmx::{htmx_reload_table, with_toast_success}},
     layout::admin_layout,
     pages::team_detail::team_detail_page,
     pages::teams::{team_create_modal, team_edit_modal, team_list_content, teams_page},
@@ -220,8 +221,6 @@ pub async fn team_create(
     .await
     {
         Ok(_) => {
-            use axum::http::header::{HeaderMap, HeaderName};
-
             // Return HTMX response to close modal and reload table
             // Trigger entity-created event for dashboard stats update
             let mut headers = HeaderMap::new();
@@ -331,13 +330,10 @@ pub async fn team_update(
     {
         Ok(true) => {
             // Return HTMX response to close modal and reload table
-            use axum::http::header::{HeaderMap, HeaderName};
-            let mut headers = HeaderMap::new();
-            headers.insert(
-                HeaderName::from_static("hx-toast-success"),
-                t.messages.teams_updated().to_string().parse().unwrap(),
-            );
-            (headers, htmx_reload_table("/teams/list", "teams-table")).into_response()
+            with_toast_success(
+                &t.messages.teams_updated().to_string(),
+                htmx_reload_table("/teams/list", "teams-table"),
+            )
         }
         Ok(false) => {
             Html(error_message(&t, t.messages.error_team_not_found()).into_string()).into_response()
@@ -401,20 +397,10 @@ pub async fn team_delete(
             }
 
             // Return HTMX response to reload table with filters
-            use axum::http::header::{HeaderMap, HeaderName};
-            let mut headers = HeaderMap::new();
-            headers.insert(
-                HeaderName::from_static("hx-toast-success"),
-                t.messages.teams_deleted().to_string().parse().unwrap(),
-            );
-            (
-                headers,
-                Html(format!(
-                    "<div hx-get=\"{}\" hx-target=\"#teams-table\" hx-trigger=\"load\" hx-swap=\"outerHTML\"></div>",
-                    reload_url
-                )),
+            with_toast_success(
+                &t.messages.teams_deleted().to_string(),
+                htmx_reload_table(&reload_url, "teams-table"),
             )
-                .into_response()
         }
         Ok(false) => Html(
             crate::views::components::error::error_message(&t, t.messages.error_team_not_found())

--- a/src/routes/teams.rs
+++ b/src/routes/teams.rs
@@ -15,7 +15,10 @@ use crate::service::{
 };
 use crate::validation::validate_name;
 use crate::views::{
-    components::{error::error_message, htmx::{htmx_reload_table, with_toast_success}},
+    components::{
+        error::error_message,
+        htmx::{htmx_reload_table, with_toast_success},
+    },
     layout::admin_layout,
     pages::team_detail::team_detail_page,
     pages::teams::{team_create_modal, team_edit_modal, team_list_content, teams_page},

--- a/src/views/components/htmx.rs
+++ b/src/views/components/htmx.rs
@@ -1,4 +1,7 @@
-use axum::response::Html;
+use axum::{
+    http::{HeaderMap, HeaderName, HeaderValue},
+    response::{Html, IntoResponse},
+};
 
 /// Helper function to generate HTMX reload trigger for tables
 ///
@@ -31,4 +34,26 @@ pub fn htmx_reload_table(endpoint: &str, target_id: &str) -> Html<String> {
 /// ```
 pub fn htmx_reload_page() -> Html<String> {
     Html("<div hx-get=\"\" hx-target=\"body\" hx-trigger=\"load\" hx-swap=\"outerHTML\" hx-push-url=\"true\"></div>".to_string())
+}
+
+/// Wrap any HTMX response body with an `hx-toast-success` header.
+///
+/// This is the standard way to trigger a success toast notification after a
+/// successful CRUD operation. The message is taken from an i18n key via
+/// `t.messages.some_key().to_string()`.
+///
+/// # Example
+/// ```rust
+/// with_toast_success(
+///     &t.messages.teams_updated().to_string(),
+///     htmx_reload_table("/teams/list", "teams-table"),
+/// )
+/// ```
+pub fn with_toast_success<T: IntoResponse>(message: &str, body: T) -> impl IntoResponse {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        HeaderName::from_static("hx-toast-success"),
+        HeaderValue::from_str(message).expect("toast message should be a valid header value"),
+    );
+    (headers, body).into_response()
 }

--- a/src/views/components/htmx.rs
+++ b/src/views/components/htmx.rs
@@ -1,6 +1,6 @@
 use axum::{
     http::{HeaderMap, HeaderName, HeaderValue},
-    response::{Html, IntoResponse},
+    response::{Html, IntoResponse, Response},
 };
 
 /// Helper function to generate HTMX reload trigger for tables
@@ -49,7 +49,7 @@ pub fn htmx_reload_page() -> Html<String> {
 ///     htmx_reload_table("/teams/list", "teams-table"),
 /// )
 /// ```
-pub fn with_toast_success<T: IntoResponse>(message: &str, body: T) -> impl IntoResponse {
+pub fn with_toast_success<T: IntoResponse>(message: &str, body: T) -> Response {
     let mut headers = HeaderMap::new();
     headers.insert(
         HeaderName::from_static("hx-toast-success"),

--- a/src/views/components/mod.rs
+++ b/src/views/components/mod.rs
@@ -10,3 +10,11 @@ pub mod table;
 pub mod toast;
 
 pub use sidebar::sidebar;
+
+/// URL-encoded SVG data URI used as a fallback avatar when a player photo fails to load.
+///
+/// Renders a grey circle with a "?" character. Use this in `onerror` attributes:
+/// ```html
+/// onerror="this.src='{AVATAR_FALLBACK_SVG}'"
+/// ```
+pub const AVATAR_FALLBACK_SVG: &str = "data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ccircle cx=%2250%22 cy=%2250%22 r=%2250%22 fill=%22%23e5e7eb%22/%3E%3Ctext x=%2250%25%22 y=%2250%25%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2240%22 fill=%22%23666%22%3E%3F%3C/text%3E%3C/svg%3E";

--- a/src/views/pages/player_detail.rs
+++ b/src/views/pages/player_detail.rs
@@ -8,6 +8,7 @@ use crate::service::players::{
 };
 use crate::views::components::confirm::{confirm_attrs, ConfirmVariant};
 use crate::views::components::forms::csrf_token_field;
+use crate::views::components::AVATAR_FALLBACK_SVG;
 
 /// Player detail page with career history and scoring
 pub fn player_detail_page(
@@ -113,7 +114,7 @@ fn player_info_card(t: &TranslationContext, player: &PlayerEntity) -> Markup {
                             src=(photo_path)
                             alt=(player.name)
                             style="width: 120px; height: 120px; object-fit: cover; border-radius: 50%; border: 3px solid var(--gray-300);"
-                            onerror="this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ccircle cx=%2250%22 cy=%2250%22 r=%2250%22 fill=%22%23e5e7eb%22/%3E%3Ctext x=%2250%25%22 y=%2250%25%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2240%22 fill=%22%23666%22%3E%3F%3C/text%3E%3C/svg%3E'";
+                            onerror=(format!("this.src='{}'", AVATAR_FALLBACK_SVG));
                     }
                 }
                 div {

--- a/src/views/pages/players.rs
+++ b/src/views/pages/players.rs
@@ -7,6 +7,7 @@ use crate::views::components::crud::{
     empty_state, modal_form_multipart, page_header, pagination, table_actions,
 };
 use crate::views::components::forms::csrf_token_field;
+use crate::views::components::AVATAR_FALLBACK_SVG;
 
 /// Main players page with table and filters
 pub fn players_page(
@@ -158,7 +159,7 @@ pub fn player_list_content(
                                             src=(photo_path)
                                             alt=(format!("{} photo", player.name))
                                             style="width: 40px; height: 40px; object-fit: cover; border-radius: 50%; border: 2px solid var(--gray-300);"
-                                            onerror="this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ccircle cx=%2250%22 cy=%2250%22 r=%2250%22 fill=%22%23e5e7eb%22/%3E%3Ctext x=%2250%25%22 y=%2250%25%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2240%22 fill=%22%23666%22%3E%3F%3C/text%3E%3C/svg%3E'";
+                                            onerror=(format!("this.src='{}'", AVATAR_FALLBACK_SVG));
                                     } @else {
                                         div
                                             style="width: 40px; height: 40px; border-radius: 50%; background: var(--gray-200); display: flex; align-items: center; justify-content: center; font-weight: 600; color: var(--gray-600);"

--- a/src/views/pages/roster.rs
+++ b/src/views/pages/roster.rs
@@ -4,6 +4,7 @@ use crate::i18n::TranslationContext;
 use crate::service::player_contracts::{PlayerInRoster, TeamParticipationContext};
 use crate::views::components::confirm::{confirm_attrs, ConfirmVariant};
 use crate::views::components::crud::modal_form_i18n;
+use crate::views::components::AVATAR_FALLBACK_SVG;
 
 /// Main roster management page
 pub fn roster_page(
@@ -125,7 +126,7 @@ fn roster_table(roster: &[PlayerInRoster]) -> Markup {
                                         src=(photo)
                                         alt=(player.player_name)
                                         style="width: 40px; height: 40px; border-radius: 50%; object-fit: cover;"
-                                        onerror="this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ccircle cx=%2250%22 cy=%2250%22 r=%2250%22 fill=%22%23e5e7eb%22/%3E%3Ctext x=%2250%25%22 y=%2250%25%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2240%22 fill=%22%23666%22%3E%3F%3C/text%3E%3C/svg%3E'";
+                                        onerror=(format!("this.src='{}'", AVATAR_FALLBACK_SVG));
                                 }
                                 span style="font-weight: 500;" {
                                     (player.player_name)


### PR DESCRIPTION
## Summary

- **`with_toast_success` helper** — extracted from 9 identical 5-line `HeaderMap::new() / insert(hx-toast-success) / into_response()` blocks across all five route modules into a single reusable function in `htmx.rs`
- **`AVATAR_FALLBACK_SVG` constant** — the same 200-char URL-encoded SVG data URI was copy-pasted into `player_detail.rs`, `players.rs`, and `roster.rs`; now lives in one place
- **`season_update` inline HTML string** — was the only handler using a raw `"<div hx-get=..."` string instead of `htmx_reload_table()`; now consistent with all others
- **Module-level imports** — `HeaderMap`/`HeaderName` were declared inside match arm bodies in `events.rs`, `teams.rs`, and `players/handlers.rs`; moved to module-level where they already existed in `seasons.rs` and `matches/crud.rs`

Net change: **-13 lines**, no behaviour change.

## Test plan
- [ ] CI passes (no new code, only refactoring)
- [ ] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)