### PR TITLE
fix: add missing CSRF token to add-team-to-season modal (422 error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Delete buttons on player, team, and season detail pages now work correctly — they were missing CSRF tokens because the buttons were not inside a `<form>` element, causing every delete action to return a 422 error
 - Removing a team from a season now works correctly — the remove button on the season detail page had the same missing CSRF token issue
+- Adding a team to a season now works correctly — the form was missing a CSRF token hidden field, causing every submission to fail with a 422 Unprocessable Entity error
 - Required and out-of-range form fields now get a red border highlight automatically via the CSS `:user-invalid` pseudo-class, giving immediate visual feedback when a field fails HTML5 validation constraints (#186)
 - Match create/edit form now uses the shared `.form-group` / `.form-label` CSS classes instead of duplicated inline styles, so it benefits from all form styling improvements consistently (#186)
 - CI formatting check now passes after applying `rustfmt` style to player validation functions introduced in #170 — the method chains were broken at the call site instead of after the `=`, which is what `rustfmt` enforces (#170)

--- a/src/routes/seasons.rs
+++ b/src/routes/seasons.rs
@@ -680,7 +680,7 @@ pub async fn season_detail(
 
 /// GET /seasons/{season_id}/teams/add - Show add team modal
 pub async fn season_add_team_form(
-    Extension(_session): Extension<Session>,
+    Extension(session): Extension<Session>,
     Extension(t): Extension<TranslationContext>,
     State(state): State<AppState>,
     Path(season_id): Path<i64>,
@@ -689,7 +689,7 @@ pub async fn season_add_team_form(
         .await
         .unwrap_or_default();
 
-    Html(add_team_modal(&t, season_id, None, &available_teams).into_string())
+    Html(add_team_modal(&session, &t, season_id, None, &available_teams).into_string())
 }
 
 /// POST /seasons/{season_id}/teams - Add team to season
@@ -715,6 +715,7 @@ pub async fn season_add_team(
         Ok(true) => {
             return Html(
                 add_team_modal(
+                    &session,
                     &t,
                     season_id,
                     Some("This team is already participating in this season"),
@@ -728,6 +729,7 @@ pub async fn season_add_team(
             tracing::error!("Failed to check team participation: {}", e);
             return Html(
                 add_team_modal(
+                    &session,
                     &t,
                     season_id,
                     Some("Failed to check team participation"),
@@ -751,6 +753,7 @@ pub async fn season_add_team(
             tracing::error!("Failed to get event_id for season: {}", e);
             return Html(
                 add_team_modal(
+                    &session,
                     &t,
                     season_id,
                     Some("Failed to get season information"),
@@ -788,6 +791,7 @@ pub async fn season_add_team(
             tracing::error!("Failed to add team to season: {}", e);
             Html(
                 add_team_modal(
+                    &session,
                     &t,
                     season_id,
                     Some("Failed to add team. Please try again."),

--- a/src/views/pages/season_detail.rs
+++ b/src/views/pages/season_detail.rs
@@ -219,12 +219,14 @@ fn empty_teams_state(t: &TranslationContext) -> Markup {
 
 /// Modal form to add a team to the season
 pub fn add_team_modal(
+    session: &Session,
     t: &TranslationContext,
     season_id: i64,
     error: Option<&str>,
     available_teams: &[(i64, String)],
 ) -> Markup {
     let form_fields = html! {
+        (csrf_token_field(&session.csrf_token))
         div style="margin-bottom: 1.5rem;" {
             label style="display: block; margin-bottom: 0.5rem; font-weight: 500;" {
                 (t.messages.seasons_select_team())


### PR DESCRIPTION
## Summary

- **Root cause**: `add_team_modal` in `season_detail.rs` had no `session` parameter, so it never included the `csrf_token` hidden `<input>` field that all other modal forms have
- **Symptom**: every POST to `/seasons/:id/teams` returned 422 — Axum failed to deserialize `AddTeamForm` because `csrf_token` was missing from the request body
- **Fix**: add `session: &Session` as the first parameter to `add_team_modal`, inject `csrf_token_field(&session.csrf_token)` as the first form field, and update the 6 call sites in `seasons.rs` (including un-ignoring the `_session` binding in `season_add_team_form`)

This follows the exact same pattern already used by `season_create_modal`, `team_create_modal`, `player_create_modal`, etc.

## Test plan
- [ ] CI passes
- [ ] Manually: open a season detail page → click "Add Team" → select a team → submit → team appears in the list without a 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)