### PR TITLE
fix: add CSRF tokens to detail page delete/remove buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error handling code in player validation is now clearer and more maintainable, removing confusing nested Result types that made the code harder to understand (#170)
 
 ### Fixed
+- Delete buttons on player, team, and season detail pages now work correctly — they were missing CSRF tokens because the buttons were not inside a `<form>` element, causing every delete action to return a 422 error
+- Removing a team from a season now works correctly — the remove button on the season detail page had the same missing CSRF token issue
 - Required and out-of-range form fields now get a red border highlight automatically via the CSS `:user-invalid` pseudo-class, giving immediate visual feedback when a field fails HTML5 validation constraints (#186)
 - Match create/edit form now uses the shared `.form-group` / `.form-label` CSS classes instead of duplicated inline styles, so it benefits from all form styling improvements consistently (#186)
 - CI formatting check now passes after applying `rustfmt` style to player validation functions introduced in #170 — the method chains were broken at the call site instead of after the `=`, which is what `rustfmt` enforces (#170)

--- a/src/routes/players/handlers.rs
+++ b/src/routes/players/handlers.rs
@@ -561,6 +561,7 @@ pub async fn player_detail(
     };
 
     let content = player_detail_page(
+        &session,
         &t,
         &page_data.detail,
         &page_data.season_stats,

--- a/src/routes/seasons.rs
+++ b/src/routes/seasons.rs
@@ -674,7 +674,7 @@ pub async fn season_detail(
         }
     };
 
-    let content = season_detail_page(&t, &detail);
+    let content = season_detail_page(&session, &t, &detail);
     Html(admin_layout("Season Detail", &session, "/seasons", &t, content).into_string())
 }
 

--- a/src/routes/teams.rs
+++ b/src/routes/teams.rs
@@ -477,7 +477,7 @@ pub async fn team_detail(
         }
     };
 
-    let content = team_detail_page(&t, &detail);
+    let content = team_detail_page(&session, &t, &detail);
     Html(admin_layout("Team Detail", &session, "/teams", &t, content).into_string())
 }
 

--- a/src/views/pages/player_detail.rs
+++ b/src/views/pages/player_detail.rs
@@ -1,14 +1,17 @@
 use maud::{html, Markup};
 
+use crate::auth::Session;
 use crate::i18n::TranslationContext;
 use crate::service::players::{
     PlayerContractWithTeamEntity, PlayerDetailEntity, PlayerEntity, PlayerEventStatsEntity,
     PlayerSeasonStats, PropertyChangeEntity,
 };
 use crate::views::components::confirm::{confirm_attrs, ConfirmVariant};
+use crate::views::components::forms::csrf_token_field;
 
 /// Player detail page with career history and scoring
 pub fn player_detail_page(
+    session: &Session,
     t: &TranslationContext,
     detail: &PlayerDetailEntity,
     season_stats: &[PlayerSeasonStats],
@@ -49,18 +52,22 @@ pub fn player_detail_page(
                     {
                         (t.messages.players_edit())
                     }
-                    button
-                        class="btn btn-danger"
-                        hx-post=(format!("/players/{}/delete", player.id))
-                        hx-confirm-custom=(confirm_attrs(
-                            &format!("{} \"{}\"", t.messages.common_delete(), player.name),
-                            &t.messages.players_confirm_delete().to_string(),
-                            ConfirmVariant::Danger,
-                            Some(&t.messages.common_delete().to_string()),
-                            Some(&t.messages.common_cancel().to_string())
-                        ))
-                    {
-                        (t.messages.players_delete())
+                    form style="display: inline;" {
+                        (csrf_token_field(&session.csrf_token))
+                        button
+                            type="submit"
+                            class="btn btn-danger"
+                            hx-post=(format!("/players/{}/delete", player.id))
+                            hx-confirm-custom=(confirm_attrs(
+                                &format!("{} \"{}\"", t.messages.common_delete(), player.name),
+                                &t.messages.players_confirm_delete().to_string(),
+                                ConfirmVariant::Danger,
+                                Some(&t.messages.common_delete().to_string()),
+                                Some(&t.messages.common_cancel().to_string())
+                            ))
+                        {
+                            (t.messages.players_delete())
+                        }
                     }
                 }
             }

--- a/src/views/pages/season_detail.rs
+++ b/src/views/pages/season_detail.rs
@@ -90,7 +90,7 @@ pub fn season_detail_page(
                 @if detail.participating_teams.is_empty() {
                     (empty_teams_state(t))
                 } @else {
-                    (teams_list(t, &detail.participating_teams))
+                    (teams_list(session, t, &detail.participating_teams))
                 }
             }
 
@@ -140,7 +140,11 @@ fn season_info_card(
 }
 
 /// Teams list in grid layout with flags and action buttons
-fn teams_list(t: &TranslationContext, teams: &[TeamParticipationEntity]) -> Markup {
+fn teams_list(
+    session: &Session,
+    t: &TranslationContext,
+    teams: &[TeamParticipationEntity],
+) -> Markup {
     html! {
         div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 1rem;" {
             @for team in teams {

--- a/src/views/pages/season_detail.rs
+++ b/src/views/pages/season_detail.rs
@@ -9,7 +9,11 @@ use crate::views::components::crud::modal_form_i18n;
 use crate::views::components::forms::csrf_token_field;
 
 /// Season detail page with team participation management
-pub fn season_detail_page(session: &Session, t: &TranslationContext, detail: &SeasonDetailEntity) -> Markup {
+pub fn season_detail_page(
+    session: &Session,
+    t: &TranslationContext,
+    detail: &SeasonDetailEntity,
+) -> Markup {
     let season = &detail.season_info;
 
     html! {

--- a/src/views/pages/season_detail.rs
+++ b/src/views/pages/season_detail.rs
@@ -1,13 +1,15 @@
 use maud::{html, Markup};
 
+use crate::auth::Session;
 use crate::i18n::TranslationContext;
 use crate::service::seasons::SeasonDetailEntity;
 use crate::service::team_participations::TeamParticipationEntity;
 use crate::views::components::confirm::{confirm_attrs, ConfirmVariant};
 use crate::views::components::crud::modal_form_i18n;
+use crate::views::components::forms::csrf_token_field;
 
 /// Season detail page with team participation management
-pub fn season_detail_page(t: &TranslationContext, detail: &SeasonDetailEntity) -> Markup {
+pub fn season_detail_page(session: &Session, t: &TranslationContext, detail: &SeasonDetailEntity) -> Markup {
     let season = &detail.season_info;
 
     html! {
@@ -38,22 +40,26 @@ pub fn season_detail_page(t: &TranslationContext, detail: &SeasonDetailEntity) -
                     {
                         (t.messages.seasons_edit())
                     }
-                    button
-                        class="btn btn-danger"
-                        hx-post=(format!("/seasons/{}/delete", season.id))
-                        hx-confirm-custom=(confirm_attrs(
-                            &format!(
-                                "{} \"{}\"",
-                                t.messages.common_delete(),
-                                season.display_name.as_deref().unwrap_or(&season.event_name)
-                            ),
-                            &t.messages.seasons_confirm_delete().to_string(),
-                            ConfirmVariant::Danger,
-                            Some(&t.messages.common_delete().to_string()),
-                            Some(&t.messages.common_cancel().to_string())
-                        ))
-                    {
-                        (t.messages.seasons_delete())
+                    form style="display: inline;" {
+                        (csrf_token_field(&session.csrf_token))
+                        button
+                            type="submit"
+                            class="btn btn-danger"
+                            hx-post=(format!("/seasons/{}/delete", season.id))
+                            hx-confirm-custom=(confirm_attrs(
+                                &format!(
+                                    "{} \"{}\"",
+                                    t.messages.common_delete(),
+                                    season.display_name.as_deref().unwrap_or(&season.event_name)
+                                ),
+                                &t.messages.seasons_confirm_delete().to_string(),
+                                ConfirmVariant::Danger,
+                                Some(&t.messages.common_delete().to_string()),
+                                Some(&t.messages.common_cancel().to_string())
+                            ))
+                        {
+                            (t.messages.seasons_delete())
+                        }
                     }
                 }
             }
@@ -158,22 +164,26 @@ fn teams_list(t: &TranslationContext, teams: &[TeamParticipationEntity]) -> Mark
                         {
                             "Manage Roster"
                         }
-                        button
-                            class="btn btn-sm btn-danger"
-                            hx-post=(format!("/team-participations/{}/delete", team.id))
-                            hx-confirm-custom=(confirm_attrs(
-                                &t.messages.seasons_remove_team().to_string(),
-                                &format!("{} {} {}",
-                                    t.messages.seasons_confirm_remove_team_1(),
-                                    team.team_name,
-                                    t.messages.seasons_confirm_remove_team_2()
-                                ),
-                                ConfirmVariant::Danger,
-                                Some(&t.messages.common_remove().to_string()),
-                                Some(&t.messages.common_cancel().to_string())
-                            ))
-                        {
-                            (t.messages.common_remove())
+                        form style="display: inline;" {
+                            (csrf_token_field(&session.csrf_token))
+                            button
+                                type="submit"
+                                class="btn btn-sm btn-danger"
+                                hx-post=(format!("/team-participations/{}/delete", team.id))
+                                hx-confirm-custom=(confirm_attrs(
+                                    &t.messages.seasons_remove_team().to_string(),
+                                    &format!("{} {} {}",
+                                        t.messages.seasons_confirm_remove_team_1(),
+                                        team.team_name,
+                                        t.messages.seasons_confirm_remove_team_2()
+                                    ),
+                                    ConfirmVariant::Danger,
+                                    Some(&t.messages.common_remove().to_string()),
+                                    Some(&t.messages.common_cancel().to_string())
+                                ))
+                            {
+                                (t.messages.common_remove())
+                            }
                         }
                     }
                 }

--- a/src/views/pages/team_detail.rs
+++ b/src/views/pages/team_detail.rs
@@ -7,7 +7,11 @@ use crate::views::components::confirm::{confirm_attrs, ConfirmVariant};
 use crate::views::components::forms::csrf_token_field;
 
 /// Team detail page with season participation management
-pub fn team_detail_page(session: &Session, t: &TranslationContext, detail: &TeamDetailEntity) -> Markup {
+pub fn team_detail_page(
+    session: &Session,
+    t: &TranslationContext,
+    detail: &TeamDetailEntity,
+) -> Markup {
     let team = &detail.team_info;
 
     html! {

--- a/src/views/pages/team_detail.rs
+++ b/src/views/pages/team_detail.rs
@@ -1,11 +1,13 @@
 use maud::{html, Markup};
 
+use crate::auth::Session;
 use crate::i18n::TranslationContext;
 use crate::service::teams::{TeamDetailEntity, TeamEntity, TeamParticipationWithSeasonEntity};
 use crate::views::components::confirm::{confirm_attrs, ConfirmVariant};
+use crate::views::components::forms::csrf_token_field;
 
 /// Team detail page with season participation management
-pub fn team_detail_page(t: &TranslationContext, detail: &TeamDetailEntity) -> Markup {
+pub fn team_detail_page(session: &Session, t: &TranslationContext, detail: &TeamDetailEntity) -> Markup {
     let team = &detail.team_info;
 
     html! {
@@ -32,18 +34,22 @@ pub fn team_detail_page(t: &TranslationContext, detail: &TeamDetailEntity) -> Ma
                     {
                         (t.messages.teams_edit())
                     }
-                    button
-                        class="btn btn-danger"
-                        hx-post=(format!("/teams/{}/delete", team.id))
-                        hx-confirm-custom=(confirm_attrs(
-                            &format!("{} \"{}\"", t.messages.common_delete(), team.name),
-                            &t.messages.teams_confirm_delete().to_string(),
-                            ConfirmVariant::Danger,
-                            Some(&t.messages.common_delete().to_string()),
-                            Some(&t.messages.common_cancel().to_string())
-                        ))
-                    {
-                        (t.messages.teams_delete())
+                    form style="display: inline;" {
+                        (csrf_token_field(&session.csrf_token))
+                        button
+                            type="submit"
+                            class="btn btn-danger"
+                            hx-post=(format!("/teams/{}/delete", team.id))
+                            hx-confirm-custom=(confirm_attrs(
+                                &format!("{} \"{}\"", t.messages.common_delete(), team.name),
+                                &t.messages.teams_confirm_delete().to_string(),
+                                ConfirmVariant::Danger,
+                                Some(&t.messages.common_delete().to_string()),
+                                Some(&t.messages.common_cancel().to_string())
+                            ))
+                        {
+                            (t.messages.teams_delete())
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Delete buttons on **player**, **team**, and **season** detail pages were bare `hx-post` buttons with no enclosing `<form>`, so the CSRF hidden field was never sent — every delete action returned **422 Unprocessable Entity**
- The **Remove team from season** button on the season detail page had the same problem
- Fix: wrap each affected button in `<form style="display: inline;">` with `csrf_token_field`, add `session: &Session` parameter to the three view functions, update call sites in route handlers

## Root cause

`validate_csrf_token` is called in all delete/remove handlers. HTMX sends the body of the nearest `<form>` ancestor — a bare button outside any form sends an empty body, so the required `csrf_token` field is absent and Axum returns 422.

## Files changed

| File | Change |
|------|--------|
| `src/views/pages/player_detail.rs` | Add `session` param, wrap delete button in form |
| `src/views/pages/team_detail.rs` | Add `session` param, wrap delete button in form |
| `src/views/pages/season_detail.rs` | Add `session` param, wrap delete-season and remove-team buttons in forms |
| `src/routes/players/handlers.rs` | Pass `&session` to `player_detail_page` |
| `src/routes/seasons.rs` | Pass `&session` to `season_detail_page` |
| `src/routes/teams.rs` | Pass `&session` to `team_detail_page` |
| `CHANGELOG.md` | Document the fix |

## Test plan

- [ ] Open a player detail page → click Delete → confirm → player is deleted (was 422 before)
- [ ] Open a team detail page → click Delete → confirm → team is deleted
- [ ] Open a season detail page → click Delete → confirm → season is deleted
- [ ] Open a season detail page with participating teams → click Remove on a team → team is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)